### PR TITLE
Rename strictRequestBody to entireRequestBody.

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -34,7 +34,7 @@ import           Network.Wai.Handler.Warp ( runSettings
 getBody :: Handler s IO LB.ByteString
 getBody = do
     req <- request
-    liftIO (strictRequestBody req)
+    liftIO (entireRequestBody req)
 
 readBody :: Handler s IO Integer
 readBody = read . unpack <$> getBody

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -17,7 +17,7 @@ module Airship.Types
     , ResponseState(..)
     , ResponseBody(..)
     , defaultRequest
-    , strictRequestBody
+    , entireRequestBody
     , eitherResponse
     , escapedResponse
     , runWebmachine
@@ -102,10 +102,10 @@ defaultRequest = Request
     , requestHeaderRange = Nothing
     }
 
--- | Extracts the entirety of a request body from a given 'Request', taking into account chunked requests.
--- Despite the name, this function actually returns a lazy 'ByteString'.
-strictRequestBody :: Monad m => Request m -> m LB.ByteString
-strictRequestBody req = requestBody req >>= strictRequestBody' LB.empty
+-- | Reads the entirety of the request body in a single string.
+-- This turns the chunks obtained from repeated invocations of 'requestBody' into a lazy 'ByteString'.
+entireRequestBody :: Monad m => Request m -> m LB.ByteString
+entireRequestBody req = requestBody req >>= strictRequestBody' LB.empty
     where strictRequestBody' acc prev
             | BS.null prev = return acc
             | otherwise = requestBody req >>= strictRequestBody' (acc <> LB.fromStrict prev)

--- a/test/unit/test.hs
+++ b/test/unit/test.hs
@@ -40,10 +40,10 @@ nextBody = do
             return h
 
 bodyTest :: TestTree
-bodyTest = testCase "strictRequestBody returns the body in the correct order" bodyTest'
+bodyTest = testCase "entireRequestBody returns the body in the correct order" bodyTest'
     where bodyTest' = evalState state bodyChunks @?= "onetwothreefourfive"
           state :: RequestState LB.ByteString
-          state = strictRequestBody req
+          state = entireRequestBody req
           req = defRequest { requestBody = nextBody }
           -- for some reason this type signature seems to be necessary
           defRequest :: Request RequestState


### PR DESCRIPTION
Bit confusing to have a function beginning with "strict" that ultimately returns a lazy ByteString.
