### PR TITLE
Generalize and explain the purpose/use of (#>).

### DIFF
--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -13,7 +13,7 @@ import Data.HashMap.Strict (HashMap, insert)
 
 import Control.Applicative (Applicative)
 import Control.Monad.Writer (Writer, execWriter)
-import Control.Monad.Writer.Class (MonadWriter, tell)
+import Control.Monad.Writer.Class (MonadWriter)
 
 import Data.String (IsString, fromString)
 
@@ -31,11 +31,6 @@ instance IsString Route where
 
 runRouter :: RoutingSpec s m a -> [(Route, Resource s m)]
 runRouter routes = execWriter (getRouter routes)
-
--- | Used in 'RoutingSpec' declarations to indicate that a particular 'Route' maps
--- to a given 'Resource'.
-(#>) :: Monad m => Route -> Resource s m -> RoutingSpec s m ()
-p #> r = tell [(p, r)]
 
 -- | @a '</>' b@ separates the path components @a@ and @b@ with a slash.
 -- This is actually just a synonym for 'mappend'.

--- a/src/Airship/Route.hs
+++ b/src/Airship/Route.hs
@@ -8,4 +8,5 @@ module Airship.Route
     , (#>)
     ) where
 
+import           Airship.Types
 import           Airship.Internal.Route

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -246,7 +246,7 @@ finishWith = Webmachine . left
 -- can be represented as such:
 --
 -- @
---     do
+--     execWriter $ do
 --       "run" #> "jewels"
 --       "blue" #> "suede"
 --       "zion" #> "wolf"

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -33,6 +33,7 @@ module Airship.Types
     , putResponseBS
     , halt
     , finishWith
+    , (#>)
     ) where
 
 import Blaze.ByteString.Builder (Builder)
@@ -50,7 +51,7 @@ import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Control (MonadBaseControl(..))
 import Control.Monad.Trans.Either (EitherT(..), runEitherT, left)
 import Control.Monad.Trans.RWS.Strict (RWST(..), runRWST)
-import Control.Monad.Writer.Class (MonadWriter)
+import Control.Monad.Writer.Class (MonadWriter, tell)
 import Data.ByteString.Char8
 import Data.HashMap.Strict (HashMap)
 import Data.Monoid ((<>))
@@ -234,6 +235,28 @@ halt status = finishWith =<< Response <$> pure status <*> getResponseHeaders <*>
 -- | Immediately halts processing and writes the provided 'Response' back to the client.
 finishWith :: Response m -> Handler s m a
 finishWith = Webmachine . left
+
+-- | The @#>@ operator provides syntactic sugar for the construction of association lists.
+-- For example, the following assoc list:
+--
+-- @
+--     [("run", "jewels"), ("blue", "suede"), ("zion", "wolf")]
+-- @
+--
+-- can be represented as such:
+--
+-- @
+--     do
+--       "run" #> "jewels"
+--       "blue" #> "suede"
+--       "zion" #> "wolf"
+-- @
+--
+-- It used in 'RoutingSpec' declarations to indicate that a particular 'Route' maps
+-- to a given 'Resource', but can be used in many other places where association lists
+-- are expected, such as 'contentTypesProvided'.
+(#>) :: MonadWriter [(k, v)] m => k -> v -> m ()
+k #> v = tell [(k, v)]
 
 both :: Either a a -> a
 both = either id id


### PR DESCRIPTION
I've been using the #> operator in places beyond just routing; it fits nicely when overriding `contentTypesAccepted` and`contentTypesProvided`, both of which return association lists. Indeed, the definition is general enough to work on any Writer that accumulates key-value pairs, not just `RoutingSpec`. Give it a slightly more liberal type definition, move it to a more sensible place, and we're off to the races.
