### PR TITLE
Loosen the dependencies around global packages & blaze-builder

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -40,7 +40,7 @@ library
                       , bytestring-trie == 0.2.4.*
                       , case-insensitive
                       , cryptohash == 0.11.6.*
-                      , directory == 1.2.2.*
+                      , directory
                       , either == 4.3.*
                       , filepath >= 1.3 && < 1.5
                       , http-date
@@ -49,7 +49,7 @@ library
                       , lifted-base == 0.2.*
                       , mime-types == 0.1.0.*
                       , monad-control >= 1.0
-                      , mtl >= 2.2
+                      , mtl
                       , network
                       , old-locale
                       , random
@@ -68,10 +68,10 @@ executable airship-example
   default-language:    Haskell2010
   build-depends:        base >=4.7 && < 5
                       , airship
-                      , blaze-builder == 0.3.*
+                      , blaze-builder >=0.3 && < 0.5
                       , bytestring
                       , http-types >= 0.7
-                      , mtl == 2.2.*
+                      , mtl
                       , text
                       , time
                       , unordered-containers
@@ -90,6 +90,6 @@ test-suite unit
                , tasty            == 0.10.*
                , tasty-quickcheck == 0.8.3.*
                , tasty-hunit        >= 0.9.1 && < 0.10
-               , transformers == 0.4.2.*
+               , transformers
                , wai == 3.0.*
   ghc-options: -Wall -Werror -threaded -O1 -fno-warn-orphans


### PR DESCRIPTION
1) pre-installed packages that come with GHC 7.8 or 7.10 (different versions)
2) blaze-builder conflict between library & example app main

This works with both LTS Stackage & Nightly Stackage now.

To test:

GHC 7.8 w/ LTS stackage:

```
  rm cabal.config
  export PATH=/path/to/ghc/7.8.4/bin:$PATH
  wget http://www.stackage.org/lts/cabal.config
  cabal sandbox init
  cabal install --enable-tests --enable-benchmarks
```

GHC 7.10 w/ Nightly stackage:

```
  rm cabal.config
  export PATH=/path/to/ghc/7.10.1/bin:$PATH
  wget http://www.stackage.org/nightly/cabal.config
  cabal sandbox init
  cabal install --enable-tests --enable-benchmarks
```
