### PR TITLE
Fixed broken link to decision tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The API is highly experimental and subject to rapid, dizzying change. Caveat pro
 
 # How does it work?
 
-Airship resources are represented with a [`Resource` record type](https://github.com/helium/airship/blob/master/src/Airship/Resource.hs#L34-L106). Each field in `Resource` corresponds to an action taken in the [Webmachine decision tree](https://raw.githubusercontent.com/wiki/basho/webmachine/images/http-headers-status-v3.png). Airship provides a `defaultResource` with sensible defaults for each of these actions; you build web services by overriding fields in the default resource with your own.
+Airship resources are represented with a [`Resource` record type](https://github.com/helium/airship/blob/master/src/Airship/Resource.hs#L34-L106). Each field in `Resource` corresponds to an action taken in the [Webmachine decision tree](https://raw.githubusercontent.com/wiki/Webmachine/webmachine/images/http-headers-status-v3.png). Airship provides a `defaultResource` with sensible defaults for each of these actions; you build web services by overriding fields in the default resource with your own.
 
 Routes are declared with a simple monadic syntax:
 


### PR DESCRIPTION
Basho seems to have moved their copy, now pointing to the Webmachine org's version.
