### PR TITLE
405 Method Not Allowed should include an Allow header

### DIFF
--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -192,7 +192,9 @@ b10 r@Resource{..} = do
     allowed <- lift allowedMethods
     if requestMethod req `elem` allowed
         then b09 r
-        else lift $ halt HTTP.status405
+        else do
+            lift $ addResponseHeader ("Allow", renderHeader allowed)
+            lift $ halt HTTP.status405
 
 b09 r@Resource{..} = do
     trace "b09"

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -40,6 +40,7 @@ import           Blaze.ByteString.Builder (toByteString)
 import           Data.Maybe (fromJust, isJust)
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
+import           Data.ByteString                  (ByteString, intercalate)
 
 import           Network.HTTP.Media
 import qualified Network.HTTP.Types as HTTP
@@ -193,7 +194,7 @@ b10 r@Resource{..} = do
     if requestMethod req `elem` allowed
         then b09 r
         else do
-            lift $ addResponseHeader ("Allow", renderHeader allowed)
+            lift $ addResponseHeader ("Allow",  intercalate "," allowed)
             lift $ halt HTTP.status405
 
 b09 r@Resource{..} = do


### PR DESCRIPTION
A 405 Method Not Allowed response should include an Allow header: https://tools.ietf.org/html/rfc7231#section-6.5.5
