### PR TITLE
Add processing step to PostProcessRedirect handling

### DIFF
--- a/src/Airship/Headers.hs
+++ b/src/Airship/Headers.hs
@@ -3,11 +3,13 @@
 module Airship.Headers
     ( addResponseHeader
     , modifyResponseHeaders
+    , replaceResponseHeader
     ) where
 
-import Airship.Types (Handler, ResponseState(..))
-import Control.Monad.State.Class (modify)
-import Network.HTTP.Types (ResponseHeaders, Header)
+import           Airship.Types             (Handler, ResponseState (..))
+import           Control.Monad.State.Class (modify)
+import qualified Data.HashMap.Lazy         as HM
+import           Network.HTTP.Types        (Header, ResponseHeaders)
 
 -- | Applies the given function to the 'ResponseHeaders' present in this 'Handler''s 'ResponseState'.
 modifyResponseHeaders :: (ResponseHeaders -> ResponseHeaders) -> Handler s m ()
@@ -17,3 +19,10 @@ modifyResponseHeaders f = modify updateHeaders
 -- | Adds a given 'Header' to this handler's 'ResponseState'.
 addResponseHeader :: Header -> Handler s m ()
 addResponseHeader h = modifyResponseHeaders (h :)
+
+-- | Replaces the value for a given 'Header' in this handler's
+-- 'ResponseState' or adds it if it does not already exist.
+replaceResponseHeader :: Header -> Handler s m ()
+replaceResponseHeader (k, v) = do
+  let replaceHeader = \x -> HM.toList $ HM.insert k v (HM.fromList x)
+  modifyResponseHeaders replaceHeader

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -640,8 +640,8 @@ processPostAction (PostProcess p) r =
     lift p >> p11 r
 processPostAction (PostProcessRedirect p ts) _r = do
     locBs <- lift ts
-    lift p
     lift $ addResponseHeader ("Location", locBs)
+    lift p
     lift $ halt HTTP.status303
 
 n05 r@Resource{..} = do

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -638,8 +638,9 @@ processPostAction (PostCreateRedirect ts) r = do
     lift $ halt HTTP.status303
 processPostAction (PostProcess p) r =
     lift p >> p11 r
-processPostAction (PostProcessRedirect ts) _r = do
+processPostAction (PostProcessRedirect p ts) _r = do
     locBs <- lift ts
+    lift p
     lift $ addResponseHeader ("Location", locBs)
     lift $ halt HTTP.status303
 

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -27,7 +27,7 @@ data PostResponse s m
     = PostCreate [Text] -- ^ Treat this request as a PUT.
     | PostCreateRedirect [Text] -- ^ Treat this request as a PUT, then redirect.
     | PostProcess (Handler s m ()) -- ^ Process as a POST, but don't redirect.
-    | PostProcessRedirect (Handler s m ByteString) -- ^ Process and redirect.
+    | PostProcessRedirect (Handler s m ()) (Handler s m ByteString) -- ^ Process and redirect.
 
 data Resource s m =
     Resource { -- | Whether to allow HTTP POSTs to a missing resource. Default: false.


### PR DESCRIPTION
The POST processing portion of PostProcessRedirect handling as alluded to in the `Process and redirect` comment on the data constructor seems to be missing. Change the constructor to accept two parameters instead of one. The first is a handler function for the POST data like the input parameter to `PostProcess` and the second is the bytestring representing a redirect URL that is set as the value of the `Location` header.

Also add a `replaceReponseHeader` helper function to make it convenient for the POST processing function to override the value of the `Location` header from the `PostProcessRedirect` constructor based on the processing results of the POST data. 
