### PR TITLE
Add stack.yaml file for airship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.chs.h
 .virthualenv
 .DS_Store
+.stack-work/

--- a/airship.cabal
+++ b/airship.cabal
@@ -75,7 +75,7 @@ executable airship-example
                       , text
                       , time
                       , unordered-containers
-                      , wai == 3.0.2.*
+                      , wai == 3.0.*
                       , warp == 3.0.*
 
 test-suite unit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-2.17
+packages:
+- ./


### PR DESCRIPTION
Add stack.yaml file so that airship can be built using stack as an
alternative to cabal. Also relax the wai version restriction for the
airship example application and add the .stack-work directory to the
.gitignore file.
