### PR TITLE
Add parseFormData helper function

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -60,6 +60,7 @@ library
                       , unix == 2.7.*
                       , unordered-containers
                       , wai == 3.0.*
+                      , wai-extra == 3.0.*
 
 executable airship-example
   main-is:              Main.hs

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -1,5 +1,6 @@
 module Airship.Helpers
-    ( contentTypeMatches
+    ( parseFormData
+    , contentTypeMatches
     , fromWaiRequest
     , resourceToWai
     ) where

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -8,18 +8,18 @@ module Airship.Internal.Helpers where
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
-import           Data.ByteString               (ByteString)
-import qualified Data.ByteString.Lazy.Internal as LazyBS
+import           Data.ByteString           (ByteString)
+import qualified Data.ByteString.Lazy      as LazyBS
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 710
 import           Data.Monoid
 #endif
-import           Data.Text                     (Text, intercalate)
+import           Data.Text                 (Text, intercalate)
 import           Data.Text.Encoding
-import           Data.Time                     (getCurrentTime)
+import           Data.Time                 (getCurrentTime)
 import           Network.HTTP.Media
-import qualified Network.HTTP.Types            as HTTP
-import qualified Network.Wai                   as Wai
+import qualified Network.HTTP.Types        as HTTP
+import qualified Network.Wai               as Wai
 import           Network.Wai.Parse
 import           System.Random
 

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -8,24 +8,32 @@ module Airship.Internal.Helpers where
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
-import           Data.ByteString     (ByteString)
+import           Data.ByteString               (ByteString)
+import qualified Data.ByteString.Lazy.Internal as LazyBS
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 710
 import           Data.Monoid
 #endif
-import           Data.Text           (Text, intercalate)
+import           Data.Text                     (Text, intercalate)
 import           Data.Text.Encoding
-import           Data.Time           (getCurrentTime)
+import           Data.Time                     (getCurrentTime)
 import           Network.HTTP.Media
-import qualified Network.HTTP.Types  as HTTP
-import qualified Network.Wai         as Wai
+import qualified Network.HTTP.Types            as HTTP
+import qualified Network.Wai                   as Wai
+import           Network.Wai.Parse
 import           System.Random
 
 import           Airship.Internal.Decision
+import           Airship.Internal.Route
 import           Airship.Resource
 import           Airship.Types
-import           Airship.Internal.Route
 
+-- | Parse form data uploaded with a @Content-Type@ of either
+-- @www-form-urlencoded@ or @multipart/form-data@ to return a
+-- list of parameter names and values and a list of uploaded
+-- files and their information.
+parseFormData :: Request IO -> IO ([Param], [File LazyBS.ByteString])
+parseFormData r = parseRequestBody lbsBackEnd (waiRequest r)
 
 -- | Returns @True@ if the request's @Content-Type@ header is one of the
 -- provided media types. If the @Content-Type@ header is not present,
@@ -54,6 +62,7 @@ fromWaiRequest req = Request
     , requestBodyLength = Wai.requestBodyLength req
     , requestHeaderHost = Wai.requestHeaderHost req
     , requestHeaderRange = Wai.requestHeaderRange req
+    , waiRequest = req
     }
 
 toWaiResponse :: Response IO -> ByteString -> ByteString -> Wai.Response

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -76,19 +76,20 @@ import qualified Network.Wai as Wai
 
 -- | Very similar to WAI's @Request@ type, except generalized to an arbitrary monad @m@.
 data Request m =
-    Request { requestMethod :: Method -- ^ The request method -- @GET@, @POST@, @DELETE@, et cetera.
-            , httpVersion :: HttpVersion -- ^ The HTTP version (usually 1.1; hopefully someday 2.0).
-            , rawPathInfo :: ByteString -- ^ The unparsed path information yielded from the WAI server. You probably want 'pathInfo'.
-            , rawQueryString :: ByteString -- ^ The query string, if any, yielded from the WAI server. You probably want 'queryString'.
-            , requestHeaders :: RequestHeaders -- ^ An association list of (headername, value) pairs. See "Network.HTTP.Types.Header" for the possible values.
-            , isSecure :: Bool -- ^ Was this request made over SSL/TLS?
-            , remoteHost :: SockAddr -- ^ The address information of the client.
-            , pathInfo :: [Text] -- ^ The URL, stripped of hostname and port, split on forward-slashes
-            , queryString :: Query -- ^ Parsed query string information.
-            , requestBody :: m ByteString -- ^ A monadic action that extracts a (possibly-empty) chunk of the request body.
-            , requestBodyLength :: Wai.RequestBodyLength -- ^ Either @ChunkedBody@ or a @KnownLength 'Word64'@.
-            , requestHeaderHost :: Maybe ByteString -- ^ Contains the Host header.
+    Request { requestMethod      :: Method -- ^ The request method -- @GET@, @POST@, @DELETE@, et cetera.
+            , httpVersion        :: HttpVersion -- ^ The HTTP version (usually 1.1; hopefully someday 2.0).
+            , rawPathInfo        :: ByteString -- ^ The unparsed path information yielded from the WAI server. You probably want 'pathInfo'.
+            , rawQueryString     :: ByteString -- ^ The query string, if any, yielded from the WAI server. You probably want 'queryString'.
+            , requestHeaders     :: RequestHeaders -- ^ An association list of (headername, value) pairs. See "Network.HTTP.Types.Header" for the possible values.
+            , isSecure           :: Bool -- ^ Was this request made over SSL/TLS?
+            , remoteHost         :: SockAddr -- ^ The address information of the client.
+            , pathInfo           :: [Text] -- ^ The URL, stripped of hostname and port, split on forward-slashes
+            , queryString        :: Query -- ^ Parsed query string information.
+            , requestBody        :: m ByteString -- ^ A monadic action that extracts a (possibly-empty) chunk of the request body.
+            , requestBodyLength  :: Wai.RequestBodyLength -- ^ Either @ChunkedBody@ or a @KnownLength 'Word64'@.
+            , requestHeaderHost  :: Maybe ByteString -- ^ Contains the Host header.
             , requestHeaderRange :: Maybe ByteString -- ^ Contains the Range header.
+            , waiRequest         :: Wai.Request
             }
 
 defaultRequest :: Monad m => Request m
@@ -106,6 +107,7 @@ defaultRequest = Request
     , requestBodyLength = Wai.KnownLength 0
     , requestHeaderHost = Nothing
     , requestHeaderRange = Nothing
+    , waiRequest = Wai.defaultRequest
     }
 
 -- | Reads the entirety of the request body in a single string.


### PR DESCRIPTION
Add `parseFormData` helper function to provide a convenient way to access uploaded form data in an application using airship. The helper function uses the `parseRequestBody` function from the wai-extra package. This `parseRequestBody` function provides the ability to select different backends for file uploads, but currently `parseFormData` does not expose this and just uses the in-memory backend.

I think this function is useful, but I would appreciate feedback on a few aspects of this PR. 
1. Should there be a way to specify the backend (in-memory or temporary file are the two options) for `parseFormData` or should there just be two different helper functions?
2. `parseFormData` exposes the caller to the `Param` and `File`types from the wai-extra package. Should we try to hide these types from the caller and return a result in terms of airship types or does it not matter?
3. The `parseRequestBody` function from the wai-extra package operates on a `Wai.Request` type. I added a field to the airship `Request` record for the original `Wai.Request` and use this when `parseFormData` is called, but is it better to just discard the original `Wai.Request` and attempt to reconstruct it in the case that someone calls `parseFormData`?
