### PR TITLE
OPTIONS response should include Allow header

### DIFF
--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -242,8 +242,11 @@ b04 r@Resource{..} = do
 b03 r@Resource{..} = do
     trace "b03"
     req <- lift request
+    allowed <- lift allowedMethods
     if requestMethod req == HTTP.methodOptions
-        then lift $ halt HTTP.status200
+        then do
+            lift $ addResponseHeader ("Allow",  intercalate "," allowed)
+            lift $ halt HTTP.status200
         else c03 r
 
 ------------------------------------------------------------------------------

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -246,7 +246,7 @@ b03 r@Resource{..} = do
     if requestMethod req == HTTP.methodOptions
         then do
             lift $ addResponseHeader ("Allow",  intercalate "," allowed)
-            lift $ halt HTTP.status200
+            lift $ halt HTTP.status204
         else c03 r
 
 ------------------------------------------------------------------------------

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -35,7 +35,6 @@ import           Control.Monad.Trans.State.Strict (StateT(..), evalStateT,
                                                    get, modify)
 import           Control.Monad.Writer.Class (tell)
 
-import           Data.ByteString (ByteString)
 import           Blaze.ByteString.Builder (toByteString)
 import           Data.Maybe (fromJust, isJust)
 import           Data.Text (Text)


### PR DESCRIPTION
When an `OPTIONS` request is made the response should include an `Allow` header that specifies all the allowed HTTP methods. Also given that there's no content in the response, a `204 No Content` is probably a more appropriate status code.
