### PR TITLE
Add readParam helper for reading values from HTTP params.

### DIFF
--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -5,6 +5,7 @@ module Airship.Helpers
     , redirectPermanently
     , fromWaiRequest
     , resourceToWai
+    , readParam
     ) where
 
 import           Airship.Internal.Helpers

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -6,6 +6,7 @@ module Airship.Helpers
     , fromWaiRequest
     , resourceToWai
     , readParam
+    , readParamMaybe
     ) where
 
 import           Airship.Internal.Helpers

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -33,12 +33,15 @@ import           Airship.Types
 
 -- | Reads the parameter of the provided name and attempt to convert
 -- it to the desired 'Read'-implementing type. If the parameter is not
--- found or cannot be read successfully, the provded handler is invoed
+-- found or cannot be read successfully, the provided handler is invoked
 -- (this may often be `halt status404`).
 readParam :: Read a => Text -> Handler s m a -> Handler s m a
-readParam p def = do
+readParam p def = readParamMaybe p >>= maybe def return
+
+readParamMaybe :: Read a => Text -> Handler s m (Maybe a)
+readParamMaybe p = do
     mStr <- fmap unpack <$> HM.lookup p <$> params
-    maybe def return (mStr >>= readMaybe)
+    return $ mStr >>= readMaybe
 
 -- | Parse form data uploaded with a @Content-Type@ of either
 -- @www-form-urlencoded@ or @multipart/form-data@ to return a

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -31,13 +31,15 @@ import           Airship.Internal.Route
 import           Airship.Resource
 import           Airship.Types
 
--- | Reads the parameter of the provided name and attempt to convert
--- it to the desired 'Read'-implementing type. If the parameter is not
--- found or cannot be read successfully, the provided handler is invoked
--- (this may often be `halt status404`).
+-- | As 'readParamMaybe', except this function eliminates the @Maybe@
+-- value by invoking the provided @Handler@ should reading the provided
+-- parameter fail.
 readParam :: Read a => Text -> Handler s m a -> Handler s m a
 readParam p def = readParamMaybe p >>= maybe def return
 
+-- | Reads the parameter of the provided name and attempt to convert
+-- it to the desired 'Read'-implementing type. If the parameter is not
+-- found or cannot be read successfully, @Nothing@ is returned.
 readParamMaybe :: Read a => Text -> Handler s m (Maybe a)
 readParamMaybe p = do
     mStr <- fmap unpack <$> HM.lookup p <$> params


### PR DESCRIPTION
Jared and I were both a little bogged down by Airship's lack of a helper
for slurping and reading values from a request's HTTP params. This is my
crack at defining such a function:

`readParam :: Read a => Text -> Handler s m a -> Handler s m a`
