### PR TITLE
Generalise contentTypesAccepted signature on data Resource.

### DIFF
--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -38,8 +38,8 @@ data Resource s m =
                -- | An association list of 'MediaType's and 'Handler' actions that correspond to the accepted
                -- @Content-Type@ values that this resource can accept in a request body. If a @Content-Type@ header
                -- is present but not accounted for in 'contentTypesAccepted', processing will halt with @415 Unsupported Media Type@.
-               -- Otherwise, the corresponding 'Handler' action will be executed and processing will continue.
-             , contentTypesAccepted     :: Handler s m [(MediaType, Handler s m ())]
+               -- Otherwise, the corresponding 'Webmachine' action will be executed and processing will continue.
+             , contentTypesAccepted     :: Handler s m [(MediaType, Webmachine s m ())]
                -- | An association list of 'MediaType' values and 'ResponseBody' values. The response will be chosen
                -- by looking up the 'MediaType' that most closely matches the @Content-Type@ header. Should there be no match,
                -- processing will halt with @406 Not Acceptable@.


### PR DESCRIPTION
This should fix an issue around having to put a second return into `contentTypesAccepted`, just to satisfy the extra constraints introduced in the `Handler s m a = Monad m => Webmachine s m a` alias.

before 

``` haskell
contentTypesAccepted = return [("application/json", return stuff)]
```

which gives a rather confusing type checking exception of if you omit the return as it doesn't really feel like it's necessary in the first place.

``` haskell
    Couldn't match type ‘Webmachine State m0 ()’
                  with ‘Monad m => Webmachine State m ()’
    Expected type: Webmachine
                     State
                     m
                     [(http-media-0.6.2:Network.HTTP.Media.MediaType.Internal.MediaType,
                       Handler State m ())]
      Actual type: Webmachine
                     State
                     m
                     [(http-media-0.6.2:Network.HTTP.Media.MediaType.Internal.MediaType,
                       Webmachine State m0 ())]
```

after

``` haskell
contentTypesAccepted = return [("application/json", stuff)]
```
