### PR TITLE
Provide configuration API for Airship apps.

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -19,6 +19,7 @@ library
   hs-source-dirs: src
   ghc-options:  -Wall
   exposed-modules:   Airship
+                   , Airship.Config
                    , Airship.Headers
                    , Airship.Helpers
                    , Airship.Types
@@ -47,6 +48,7 @@ library
                       , http-media
                       , http-types == 0.8.*
                       , lifted-base == 0.2.*
+                      , microlens
                       , mime-types == 0.1.0.*
                       , monad-control >= 1.0
                       , mtl

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -1,36 +1,35 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes        #-}
 
 module Main where
 
 import           Airship
-import           Airship.Resource.Static (StaticOptions(..), staticResource)
+import           Airship.Resource.Static            (StaticOptions (..),
+                                                     staticResource)
 
 import           Blaze.ByteString.Builder.Html.Utf8 (fromHtmlEscapedText)
 
 #if __GLASGOW_HASKELL__ < 710
-import           Control.Applicative ((<$>))
+import           Control.Applicative                ((<$>))
 #endif
 import           Control.Concurrent.MVar
-import           Control.Monad.Trans (liftIO)
+import           Control.Monad.Trans                (liftIO)
 
-import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HM
-import qualified Data.ByteString.Lazy as LB
-import           Data.ByteString.Lazy.Char8 (unpack)
-import           Data.Maybe (fromMaybe)
-import           Data.Monoid ((<>))
-import           Data.Text(Text, pack)
+import qualified Data.ByteString.Lazy               as LB
+import           Data.ByteString.Lazy.Char8         (unpack)
+import           Data.HashMap.Strict                (HashMap)
+import qualified Data.HashMap.Strict                as HM
+import           Data.Maybe                         (fromMaybe)
+import           Data.Monoid                        ((<>))
+import           Data.Text                          (Text, pack)
 import           Data.Time.Clock
 
-import qualified Network.HTTP.Types as HTTP
-import           Network.Wai.Handler.Warp ( runSettings
-                                          , defaultSettings
-                                          , setPort
-                                          , setHost
-                                          )
+import qualified Network.HTTP.Types                 as HTTP
+import           Network.Wai.Handler.Warp           (defaultSettings,
+                                                     runSettings, setHost,
+                                                     setPort)
 
 -- ***************************************************************************
 -- Helpers
@@ -132,4 +131,4 @@ main = do
     mvar <- newMVar HM.empty
     let s = State mvar
     putStrLn "Listening on port 3000"
-    runSettings settings (resourceToWai routes resource404 s)
+    runSettings settings (resourceToWai defaultAirshipConfig routes resource404 s)

--- a/src/Airship.hs
+++ b/src/Airship.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes        #-}
 
 module Airship
-  ( module Airship.Resource
+  ( module Airship.Config
+  , module Airship.Resource
   , module Airship.Headers
   , module Airship.Helpers
   , module Airship.Route
   , module Airship.Types
   ) where
 
+import           Airship.Config
 import           Airship.Headers
 import           Airship.Helpers
 import           Airship.Resource

--- a/src/Airship/Config.hs
+++ b/src/Airship/Config.hs
@@ -1,0 +1,30 @@
+module Airship.Config
+    ( AirshipConfig
+    , includeTraceHeader
+    , defaultAirshipConfig
+    ) where
+
+import           Lens.Micro (Lens', lens)
+
+-- | An opaque data type encapsulating all Airship-specific configuration options.
+--
+-- We use lenses to modify 'AirshipConfig' values -- though Airship only depends on the
+-- microlens library, its lenses are compatible with Control.Lens.
+data AirshipConfig = AirshipConfig
+    { _includeTraceHeader :: Bool
+    }
+
+-- | Determines whether or not the @Airship-Trace@ header, which traces the execution of
+-- a given request in the Airship decision tree, is included in every HTTP response.
+-- While exposing the decision tree is usually innocuous (and makes for significantly easier
+-- debugging), you may want to turn it off in certain circumstances.
+--
+-- Defaults to 'True' (enabled).
+includeTraceHeader :: Lens' AirshipConfig Bool
+includeTraceHeader = lens _includeTraceHeader (\s n -> s { _includeTraceHeader = n })
+
+-- | The default configuration. Use this, in conjunction with the lenses declared
+-- above, to get and modify an 'AirshipConfig' to pass to 'resourceToWai'.
+defaultAirshipConfig :: AirshipConfig
+defaultAirshipConfig = AirshipConfig True
+

--- a/src/Airship/Config.hs
+++ b/src/Airship/Config.hs
@@ -1,5 +1,6 @@
 module Airship.Config
     ( AirshipConfig
+    , HeaderInclusion (..)
     , includeTraceHeader
     , defaultAirshipConfig
     ) where
@@ -11,20 +12,22 @@ import           Lens.Micro (Lens', lens)
 -- We use lenses to modify 'AirshipConfig' values -- though Airship only depends on the
 -- microlens library, its lenses are compatible with Control.Lens.
 data AirshipConfig = AirshipConfig
-    { _includeTraceHeader :: Bool
+    { _includeTraceHeader :: HeaderInclusion
     }
+
+data HeaderInclusion = IncludeHeader | OmitHeader deriving (Eq, Show)
 
 -- | Determines whether or not the @Airship-Trace@ header, which traces the execution of
 -- a given request in the Airship decision tree, is included in every HTTP response.
 -- While exposing the decision tree is usually innocuous (and makes for significantly easier
 -- debugging), you may want to turn it off in certain circumstances.
 --
--- Defaults to 'True' (enabled).
-includeTraceHeader :: Lens' AirshipConfig Bool
+-- Defaults to 'IncludeHeader' (enabled).
+includeTraceHeader :: Lens' AirshipConfig HeaderInclusion
 includeTraceHeader = lens _includeTraceHeader (\s n -> s { _includeTraceHeader = n })
 
 -- | The default configuration. Use this, in conjunction with the lenses declared
 -- above, to get and modify an 'AirshipConfig' to pass to 'resourceToWai'.
 defaultAirshipConfig :: AirshipConfig
-defaultAirshipConfig = AirshipConfig True
+defaultAirshipConfig = AirshipConfig IncludeHeader
 

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -92,7 +92,9 @@ toWaiResponse Response{..} cfg trace quip =
             Wai.responseBuilder _responseStatus headers mempty
     where
         headers = traced ++ [("Airship-Quip", quip)] ++ _responseHeaders
-        traced  = if cfg^.includeTraceHeader then [("Airship-Trace", trace)] else []
+        traced  = if cfg^.includeTraceHeader == IncludeHeader
+                      then [("Airship-Trace", trace)]
+                      else []
 
 -- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
 resourceToWai :: AirshipConfig -> RoutingSpec s IO () -> Resource s IO -> s -> Wai.Application

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -17,17 +17,19 @@ import           Data.Monoid
 import           Data.Text                 (Text, intercalate)
 import           Data.Text.Encoding
 import           Data.Time                 (getCurrentTime)
+import           Lens.Micro                ((^.))
 import           Network.HTTP.Media
 import qualified Network.HTTP.Types        as HTTP
 import qualified Network.Wai               as Wai
 import           Network.Wai.Parse
 import           System.Random
 
+import           Airship.Config
+import           Airship.Headers
 import           Airship.Internal.Decision
 import           Airship.Internal.Route
 import           Airship.Resource
 import           Airship.Types
-import           Airship.Headers
 
 -- | Parse form data uploaded with a @Content-Type@ of either
 -- @www-form-urlencoded@ or @multipart/form-data@ to return a
@@ -77,8 +79,8 @@ fromWaiRequest req = Request
     , waiRequest = req
     }
 
-toWaiResponse :: Response IO -> ByteString -> ByteString -> Wai.Response
-toWaiResponse Response{..} trace quip =
+toWaiResponse :: Response IO -> AirshipConfig -> ByteString -> ByteString -> Wai.Response
+toWaiResponse Response{..} cfg trace quip =
     case _responseBody of
         (ResponseBuilder b) ->
             Wai.responseBuilder _responseStatus headers b
@@ -88,11 +90,13 @@ toWaiResponse Response{..} trace quip =
             Wai.responseStream _responseStatus headers streamer
         Empty ->
             Wai.responseBuilder _responseStatus headers mempty
-    where headers = _responseHeaders ++ [("Airship-Trace", trace), ("Airship-Quip", quip)]
+    where
+        headers = traced ++ [("Airship-Quip", quip)] ++ _responseHeaders
+        traced  = if cfg^.includeTraceHeader then [("Airship-Trace", trace)] else []
 
 -- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
-resourceToWai :: RoutingSpec s IO () -> Resource s IO -> s -> Wai.Application
-resourceToWai routes resource404 s req respond = do
+resourceToWai :: AirshipConfig -> RoutingSpec s IO () -> Resource s IO -> s -> Wai.Application
+resourceToWai cfg routes resource404 s req respond = do
     let routeMapping = runRouter routes
         pInfo = Wai.pathInfo req
         airshipReq = fromWaiRequest req
@@ -100,8 +104,7 @@ resourceToWai routes resource404 s req respond = do
     nowTime <- getCurrentTime
     quip <- getQuip
     (response, trace) <- eitherResponse nowTime params' matched airshipReq s (flow resource)
-    let traceHeaderValue = traceHeader trace
-    respond (toWaiResponse response traceHeaderValue quip)
+    respond (toWaiResponse response cfg (traceHeader trace) quip)
 
 getQuip :: IO ByteString
 getQuip = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,7 @@
-resolver: lts-2.17
+flags: {}
 packages:
 - ./
 - example
+extra-deps:
+- microlens-0.3.4.1
+resolver: lts-2.17


### PR DESCRIPTION
This emulates Warp's approach towards web server settings in that it
provides a data type (`AirshipConfig`) with a hidden constructor, which
is modified through a default value and a set of functions to read/write
individual settings. We piggyback on the microlens library to provide these functions.

Please note that this is a breaking change, as it adds a parameter to
`resourceToWai`.

Fixes #49.
