### PR TITLE
Add semigroupoids to stack.yml to fix errors about profunctors

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,5 @@ packages:
 - example
 extra-deps:
 - microlens-0.3.4.1
+- semigroupoids-4.3
 resolver: lts-2.17


### PR DESCRIPTION
Apologies, this is a bit cargo-culty. I'm very new to `stack` and I don't know enough to diagnose what this really means. Any suggestions?

```
bifunctors-4.2.1: Package names may be treated case-insensitively in the future.
Package bifunctors-4.2.1 overlaps with: bifunctors-4.2.1 (ignoring)
bifunctors-4.2.1: dependency "semigroupoids-4.3-f954cd415ebe5d2998960afa60c58e9b" doesn't exist (ignoring)
```
