### PR TITLE
Remove hard-coded State and introduce hoist functions to allow for monad goodness

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -51,6 +51,7 @@ library
                       , microlens
                       , mime-types == 0.1.0.*
                       , monad-control >= 1.0
+                      , mmorph == 1.0.*
                       , mtl
                       , network
                       , old-locale

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -132,6 +132,3 @@ main = do
     let s = State mvar
     putStrLn "Listening on port 3000"
     runSettings settings (resourceToWai defaultAirshipConfig (hoist (flip evalStateT s) routes) resource404)
-
-hoist :: (forall a. m a -> n a) -> RoutingSpec m b -> RoutingSpec n b
-hoist = error "Not possible to implement yet. From MFunctor, but needs changes to airship internals"

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -35,10 +35,10 @@ import           Network.Wai.Handler.Warp           (defaultSettings,
 -- Helpers
 -- ***************************************************************************
 
-getBody :: Handler m LB.ByteString
+getBody :: MonadIO m => Handler m LB.ByteString
 getBody = do
     req <- request
-    lift (entireRequestBody req)
+    liftIO (entireRequestBody req)
 
 readBody :: MonadIO m => Handler m Integer
 readBody = read . unpack <$> getBody

--- a/src/Airship/Headers.hs
+++ b/src/Airship/Headers.hs
@@ -10,10 +10,10 @@ import Control.Monad.State.Class (modify)
 import Network.HTTP.Types (ResponseHeaders, Header)
 
 -- | Applies the given function to the 'ResponseHeaders' present in this 'Handler''s 'ResponseState'.
-modifyResponseHeaders :: (ResponseHeaders -> ResponseHeaders) -> Handler s m ()
+modifyResponseHeaders :: (ResponseHeaders -> ResponseHeaders) -> Handler m ()
 modifyResponseHeaders f = modify updateHeaders
     where updateHeaders rs@ResponseState{stateHeaders = h} = rs { stateHeaders = f h }
 
 -- | Adds a given 'Header' to this handler's 'ResponseState'.
-addResponseHeader :: Header -> Handler s m ()
+addResponseHeader :: Header -> Handler m ()
 addResponseHeader h = modifyResponseHeaders (h :)

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -3,7 +3,6 @@ module Airship.Helpers
     , contentTypeMatches
     , redirectTemporarily
     , redirectPermanently
-    , fromWaiRequest
     , resourceToWai
     ) where
 

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -71,16 +71,16 @@ hIfNoneMatch = "If-None-Match"
 ------------------------------------------------------------------------------
 
 data FlowState m = FlowState
-    { _contentType :: Maybe (MediaType, Webmachine m (ResponseBody m)) }
+    { _contentType :: Maybe (MediaType, Webmachine m ResponseBody) }
 
 type FlowStateT m a = StateT (FlowState m) (Webmachine m) a
 
-type Flow  m = Resource m -> FlowStateT m (Response m)
+type Flow m = Resource m -> FlowStateT m Response
 
 initFlowState :: FlowState m
 initFlowState = FlowState Nothing
 
-flow :: Monad m => Resource m -> Webmachine m (Response m)
+flow :: Monad m => Resource m -> Webmachine m Response
 flow r = evalStateT (b13 r) initFlowState
 
 trace :: Monad m => Text -> FlowStateT m ()

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -70,27 +70,27 @@ hIfNoneMatch = "If-None-Match"
 -- tree
 ------------------------------------------------------------------------------
 
-data FlowState s m = FlowState
-    { _contentType :: Maybe (MediaType, Webmachine s m (ResponseBody m)) }
+data FlowState m = FlowState
+    { _contentType :: Maybe (MediaType, Webmachine m (ResponseBody m)) }
 
-type FlowStateT s m a = StateT (FlowState s m) (Webmachine s m) a
+type FlowStateT m a = StateT (FlowState m) (Webmachine m) a
 
-type Flow s m = Resource s m -> FlowStateT s m (Response m)
+type Flow  m = Resource m -> FlowStateT m (Response m)
 
-initFlowState :: FlowState s m
+initFlowState :: FlowState m
 initFlowState = FlowState Nothing
 
-flow :: Monad m => Resource s m -> Webmachine s m (Response m)
+flow :: Monad m => Resource m -> Webmachine m (Response m)
 flow r = evalStateT (b13 r) initFlowState
 
-trace :: Monad m => Text -> FlowStateT s m ()
+trace :: Monad m => Text -> FlowStateT m ()
 trace t = lift $ tell [t]
 
 ------------------------------------------------------------------------------
 -- Decision Helpers
 ------------------------------------------------------------------------------
 
-negotiateContentTypesAccepted :: Monad m => Resource s m -> FlowStateT s m ()
+negotiateContentTypesAccepted :: Monad m => Resource m -> FlowStateT m ()
 negotiateContentTypesAccepted Resource{..} = do
     req <- lift request
     accepted <- lift contentTypesAccepted
@@ -102,13 +102,13 @@ negotiateContentTypesAccepted Resource{..} = do
         (Just process) -> lift process
         Nothing -> lift $ halt HTTP.status415
 
-appendRequestPath :: Monad m => [Text] -> Webmachine s m ByteString
+appendRequestPath :: Monad m => [Text] -> Webmachine m ByteString
 appendRequestPath ts = do
     currentPath <- pathInfo <$> request
     return $ toByteString (HTTP.encodePathSegments (currentPath ++ ts))
 
 requestHeaderDate :: Monad m => HTTP.HeaderName ->
-                                Webmachine s m (Maybe UTCTime)
+                                Webmachine m (Maybe UTCTime)
 requestHeaderDate headerName = do
     req <- request
     let reqHeaders = requestHeaders req
@@ -116,7 +116,7 @@ requestHeaderDate headerName = do
         parsedDate = dateHeader >>= parseRfc1123Date
     return parsedDate
 
-writeCacheTags :: Monad m => Resource s m -> FlowStateT s m ()
+writeCacheTags :: Monad m => Resource m -> FlowStateT m ()
 writeCacheTags Resource{..} = lift $ do
     etag <- generateETag
     case etag of
@@ -131,21 +131,21 @@ writeCacheTags Resource{..} = lift $ do
 -- Type definitions for all decision nodes
 ------------------------------------------------------------------------------
 
-b13, b12, b11, b10, b09, b08, b07, b06, b05, b04, b03 :: Monad m => Flow s m
-c04, c03 :: Monad m => Flow s m
-d05, d04 :: Monad m => Flow s m
-e06, e05 :: Monad m => Flow s m
-f07, f06 :: Monad m => Flow s m
-g11, g09, g08, g07 :: Monad m => Flow s m
-h12, h11, h10, h07 :: Monad m => Flow s m
-i13, i12, i07, i04 :: Monad m => Flow s m
-j18 :: Monad m => Flow s m
-k13, k07, k05 :: Monad m => Flow s m
-l17, l15, l14, l13, l07, l05 :: Monad m => Flow s m
-m20, m16, m07, m05 :: Monad m => Flow s m
-n16, n11, n05 :: Monad m => Flow s m
-o20, o18, o16, o14 :: Monad m => Flow s m
-p11, p03 :: Monad m => Flow s m
+b13, b12, b11, b10, b09, b08, b07, b06, b05, b04, b03 :: Monad m => Flow  m
+c04, c03 :: Monad m => Flow  m
+d05, d04 :: Monad m => Flow  m
+e06, e05 :: Monad m => Flow  m
+f07, f06 :: Monad m => Flow  m
+g11, g09, g08, g07 :: Monad m => Flow  m
+h12, h11, h10, h07 :: Monad m => Flow  m
+i13, i12, i07, i04 :: Monad m => Flow  m
+j18 :: Monad m => Flow  m
+k13, k07, k05 :: Monad m => Flow  m
+l17, l15, l14, l13, l07, l05 :: Monad m => Flow  m
+m20, m16, m07, m05 :: Monad m => Flow  m
+n16, n11, n05 :: Monad m => Flow  m
+o20, o18, o16, o14 :: Monad m => Flow  m
+p11, p03 :: Monad m => Flow  m
 
 ------------------------------------------------------------------------------
 -- B column
@@ -625,13 +625,13 @@ n16 r = do
 
 n11 r@Resource{..} = trace "n11" >> lift processPost >>= flip processPostAction r
 
-create :: Monad m => [Text] -> Resource s m -> FlowStateT s m ()
+create :: Monad m => [Text] -> Resource m -> FlowStateT m ()
 create ts r = do
     loc <- lift (appendRequestPath ts)
     lift (addResponseHeader ("Location", loc))
     negotiateContentTypesAccepted r
 
-processPostAction :: Monad m => PostResponse s m -> Flow s m
+processPostAction :: Monad m => PostResponse m -> Flow  m
 processPostAction (PostCreate ts) r = do
     create ts r
     p11 r

--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -32,7 +32,7 @@ data BoundOrUnbound = Bound Text
 instance IsString Route where
     fromString s = Route [Bound (fromString s)]
 
-runRouter :: RoutingSpec s m a -> [(Route, Resource s m)]
+runRouter :: RoutingSpec m a -> [(Route, Resource m)]
 runRouter routes = execWriter (getRouter routes)
 
 -- | @a '</>' b@ separates the path components @a@ and @b@ with a slash.
@@ -68,7 +68,7 @@ star = Route [RestUnbound]
 -- | Represents a fully-specified set of routes that map paths (represented as 'Route's) to 'Resource's. 'RoutingSpec's are declared with do-notation, to wit:
 --
 -- @
---    myRoutes :: RoutingSpec MyState IO ()
+--    myRoutes :: RoutingSpec IO ()
 --    myRoutes = do
 --      root                                 #> myRootResource
 --      "blog" '</>' var "date" '</>' var "post" #> blogPostResource
@@ -76,8 +76,8 @@ star = Route [RestUnbound]
 --      "anything" '</>' star                  #> wildcardResource
 -- @
 --
-newtype RoutingSpec s m a = RoutingSpec { getRouter :: Writer [(Route, Resource s m)] a }
-    deriving (Functor, Applicative, Monad, MonadWriter [(Route, Resource s m)])
+newtype RoutingSpec m a = RoutingSpec { getRouter :: Writer [(Route, Resource m)] a }
+    deriving (Functor, Applicative, Monad, MonadWriter [(Route, Resource m)])
 
 
 route :: [(Route, a)] -> [Text] -> a -> (a, (HashMap Text Text, [Text]))

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -23,96 +23,96 @@ import Network.HTTP.Media (MediaType)
 -- | Used when processing POST requests so as to handle the outcome of the binary decisions between
 -- handling a POST as a create request and whether to redirect after the POST is done.
 -- Credit for this idea goes to Richard Wallace (purefn) on Webcrank.
-data PostResponse s m
+data PostResponse m
     = PostCreate [Text] -- ^ Treat this request as a PUT.
     | PostCreateRedirect [Text] -- ^ Treat this request as a PUT, then redirect.
-    | PostProcess (Handler s m ()) -- ^ Process as a POST, but don't redirect.
-    | PostProcessRedirect (Handler s m ByteString) -- ^ Process and redirect.
+    | PostProcess (Handler m ()) -- ^ Process as a POST, but don't redirect.
+    | PostProcessRedirect (Handler m ByteString) -- ^ Process and redirect.
 
-data Resource s m =
+data Resource m =
     Resource { -- | Whether to allow HTTP POSTs to a missing resource. Default: false.
-               allowMissingPost         :: Handler s m Bool
+               allowMissingPost         :: Handler m Bool
                -- | The set of HTTP methods that this resource allows. Default: @GET@ and @HEAD@.
                -- If a request arrives with an HTTP method not included herein, @501 Not Implemented@ is returned.
-             , allowedMethods           :: Handler s m [Method]
+             , allowedMethods           :: Handler m [Method]
                -- | An association list of 'MediaType's and 'Handler' actions that correspond to the accepted
                -- @Content-Type@ values that this resource can accept in a request body. If a @Content-Type@ header
                -- is present but not accounted for in 'contentTypesAccepted', processing will halt with @415 Unsupported Media Type@.
                -- Otherwise, the corresponding 'Webmachine' action will be executed and processing will continue.
-             , contentTypesAccepted     :: Handler s m [(MediaType, Webmachine s m ())]
+             , contentTypesAccepted     :: Handler m [(MediaType, Webmachine m ())]
                -- | An association list of 'MediaType' values and 'ResponseBody' values. The response will be chosen
                -- by looking up the 'MediaType' that most closely matches the @Content-Type@ header. Should there be no match,
                -- processing will halt with @406 Not Acceptable@.
-             , contentTypesProvided     :: Handler s m [(MediaType, Webmachine s m (ResponseBody m))]
+             , contentTypesProvided     :: Handler m [(MediaType, Webmachine m (ResponseBody m))]
                -- | When a @DELETE@ request is enacted (via a @True@ value returned from 'deleteResource'), a
                -- @False@ value returns a @202 Accepted@ response. Returning @True@ will continue processing,
                -- usually ending up with a @204 No Content@ response. Default: False.
-             , deleteCompleted          :: Handler s m Bool
+             , deleteCompleted          :: Handler m Bool
                -- | When processing a @DELETE@ request, a @True@ value allows processing to continue.
                -- Returns @500 Forbidden@ if False. Default: false.
-             , deleteResource           :: Handler s m Bool
+             , deleteResource           :: Handler m Bool
                -- | Returns @413 Request Entity Too Large@ if true. Default: false.
-             , entityTooLarge           :: Handler s m Bool
+             , entityTooLarge           :: Handler m Bool
                -- | Checks if the given request is allowed to access this resource.
                -- Returns @403 Forbidden@ if true. Default: false.
-             , forbidden                :: Handler s m Bool
+             , forbidden                :: Handler m Bool
                -- | If this returns a non-'Nothing' 'ETag', its value will be added to every HTTP response
                -- in the @ETag:@ field.
-             , generateETag             :: Handler s m (Maybe ETag)
+             , generateETag             :: Handler m (Maybe ETag)
                -- | Checks if this resource has actually implemented a handler for a given HTTP method.
                -- Returns @501 Not Implemented@ if false. Default: true.
-             , implemented              :: Handler s m Bool
+             , implemented              :: Handler m Bool
                -- | Returns @401 Unauthorized@ if false. Default: true.
-             , isAuthorized             :: Handler s m Bool
+             , isAuthorized             :: Handler m Bool
                -- | When processing @PUT@ requests, a @True@ value returned here will halt processing with a @409 Created@.
-             , isConflict               :: Handler s m Bool
+             , isConflict               :: Handler m Bool
                -- | Returns @415 Unsupported Media Type@ if false. We recommend you use the 'contentTypeMatches' helper function, which accepts a list of
                -- 'MediaType' values, so as to simplify proper MIME type handling. Default: true.
-             , knownContentType         :: Handler s m Bool
+             , knownContentType         :: Handler m Bool
                -- | In the presence of an @If-Modified-Since@ header, returning a @Just@ value from 'lastModifed' allows
                -- the server to halt with @304 Not Modified@ if appropriate.
-             , lastModified             :: Handler s m (Maybe UTCTime)
+             , lastModified             :: Handler m (Maybe UTCTime)
                -- | If an @Accept-Language@ value is present in the HTTP request, and this function returns @False@,
                -- processing will halt with @406 Not Acceptable@.
-             , languageAvailable        :: Handler s m Bool
+             , languageAvailable        :: Handler m Bool
                -- | Returns @400 Bad Request@ if true. Default: false.
-             , malformedRequest         :: Handler s m Bool
+             , malformedRequest         :: Handler m Bool
                                         -- wondering if this should be text,
                                         -- or some 'path' type
                -- | When processing a resource for which 'resourceExists' returned @False@, returning a @Just@ value
                -- halts with a @301 Moved Permanently@ response. The contained 'ByteString' will be added to the
                -- HTTP response under the @Location:@ header.
-             , movedPermanently         :: Handler s m (Maybe ByteString)
+             , movedPermanently         :: Handler m (Maybe ByteString)
                -- | Like 'movedPermanently', except with a @307 Moved Temporarily@ response.
-             , movedTemporarily         :: Handler s m (Maybe ByteString)
+             , movedTemporarily         :: Handler m (Maybe ByteString)
                -- | When handling a @PUT@ request, returning @True@ here halts processing with @300 Multiple Choices@. Default: False.
-             , multipleChoices          :: Handler s m Bool
+             , multipleChoices          :: Handler m Bool
                -- | When processing a request for which 'resourceExists' returned @False@, returning @True@ here
                -- allows the 'movedPermanently' and 'movedTemporarily' functions to process the request.
-             , previouslyExisted        :: Handler s m Bool
+             , previouslyExisted        :: Handler m Bool
                -- | When handling @POST@ requests, the value returned determines whether to treat the request as a @PUT@,
                -- a @PUT@ and a redirect, or a plain @POST@. See the documentation for 'PostResponse' for more information.
                -- The default implemetation returns a 'PostProcess' with an empty handler.
-             , processPost              :: Handler s m (PostResponse s m)
+             , processPost              :: Handler m (PostResponse m)
                -- | Does the resource at this path exist?
                -- Returning false from this usually entails a @404 Not Found@ response.
                -- (If 'allowMissingPost' returns @True@ or an @If-Match: *@ header is present, it may not).
-             , resourceExists           :: Handler s m Bool
+             , resourceExists           :: Handler m Bool
                -- | Returns @503 Service Unavailable@ if false. Default: true.
-             , serviceAvailable         :: Handler s m Bool
+             , serviceAvailable         :: Handler m Bool
                -- | Returns @414 Request URI Too Long@ if true. Default: false.
-             , uriTooLong               :: Handler s m Bool
+             , uriTooLong               :: Handler m Bool
                -- | Returns @501 Not Implemented@ if false. Default: true.
-             , validContentHeaders      :: Handler s m Bool
+             , validContentHeaders      :: Handler m Bool
              }
 
 -- | A helper function that terminates execution with @500 Internal Server Error@.
-serverError :: Handler m s a
+serverError :: Handler m a
 serverError = finishWith (Response status500 [] Empty)
 
 -- | The default Airship resource, with "sensible" values filled in for each entry.
 -- You construct new resources by extending the default resource with your own handlers.
-defaultResource :: Resource s m
+defaultResource :: Resource m
 defaultResource = Resource { allowMissingPost       = return False
                            , allowedMethods         = return [methodGet, methodHead]
                            , contentTypesAccepted   = return []

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -43,7 +43,7 @@ data Resource m =
                -- | An association list of 'MediaType' values and 'ResponseBody' values. The response will be chosen
                -- by looking up the 'MediaType' that most closely matches the @Content-Type@ header. Should there be no match,
                -- processing will halt with @406 Not Acceptable@.
-             , contentTypesProvided     :: Handler m [(MediaType, Webmachine m (ResponseBody m))]
+             , contentTypesProvided     :: Handler m [(MediaType, Webmachine m ResponseBody)]
                -- | When a @DELETE@ request is enacted (via a @True@ value returned from 'deleteResource'), a
                -- @False@ value returns a @202 Accepted@ response. Returning @True@ will continue processing,
                -- usually ending up with a @204 No Content@ response. Default: False.

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -9,6 +9,7 @@ module Airship.Resource
     , PostResponse(..)
     , serverError
     , defaultResource
+    , hoistResource
     ) where
 
 import Airship.Types
@@ -28,6 +29,13 @@ data PostResponse m
     | PostCreateRedirect [Text] -- ^ Treat this request as a PUT, then redirect.
     | PostProcess (Handler m ()) -- ^ Process as a POST, but don't redirect.
     | PostProcessRedirect (Handler m ByteString) -- ^ Process and redirect.
+
+-- PostResponse can't be an MFunctor because it's missing a type hole
+hoistPostResponse :: Monad m => (forall a. m a -> n a) -> PostResponse m -> PostResponse n
+hoistPostResponse _ (PostCreate t) = PostCreate t
+hoistPostResponse _ (PostCreateRedirect t) = PostCreateRedirect t
+hoistPostResponse nat (PostProcess h) = PostProcess (hoist nat h)
+hoistPostResponse nat (PostProcessRedirect h) = PostProcessRedirect (hoist nat h)
 
 data Resource m =
     Resource { -- | Whether to allow HTTP POSTs to a missing resource. Default: false.
@@ -139,3 +147,34 @@ defaultResource = Resource { allowMissingPost       = return False
                            , uriTooLong             = return False
                            , validContentHeaders    = return True
                            }
+
+-- Resource can't be an MFunctor because it's missing a type hole
+hoistResource :: Monad m => (forall a. m a -> n a) -> Resource m -> Resource n
+hoistResource nat r =
+   Resource {
+     allowMissingPost       = hoist nat (allowMissingPost r)
+   , allowedMethods         = hoist nat (allowedMethods r)
+   , contentTypesAccepted   = fmap (fmap (\(mt, h) -> (mt, hoist nat h))) $ hoist nat (contentTypesAccepted r)
+   , contentTypesProvided   = fmap (fmap (\(mt, h) -> (mt, hoist nat h))) $ hoist nat (contentTypesProvided r)
+   , deleteCompleted        = hoist nat (deleteCompleted r)
+   , deleteResource         = hoist nat (deleteResource r)
+   , entityTooLarge         = hoist nat (entityTooLarge r)
+   , forbidden              = hoist nat (forbidden r)
+   , generateETag           = hoist nat (generateETag r)
+   , implemented            = hoist nat (implemented r)
+   , isAuthorized           = hoist nat (isAuthorized r)
+   , isConflict             = hoist nat (isConflict r)
+   , knownContentType       = hoist nat (knownContentType r)
+   , lastModified           = hoist nat (lastModified r)
+   , languageAvailable      = hoist nat (languageAvailable r)
+   , malformedRequest       = hoist nat (malformedRequest r)
+   , movedPermanently       = hoist nat (movedPermanently r)
+   , movedTemporarily       = hoist nat (movedTemporarily r)
+   , multipleChoices        = hoist nat (multipleChoices r)
+   , previouslyExisted      = hoist nat (previouslyExisted r)
+   , processPost            = fmap (hoistPostResponse nat) $ hoist nat (processPost r)
+   , resourceExists         = hoist nat (resourceExists r)
+   , serviceAvailable       = hoist nat (serviceAvailable r)
+   , uriTooLong             = hoist nat (uriTooLong r)
+   , validContentHeaders    = hoist nat (validContentHeaders r)
+   }

--- a/src/Airship/Resource/Static.hs
+++ b/src/Airship/Resource/Static.hs
@@ -113,10 +113,10 @@ directoryTree f = do
     let infos = fileInfos (zipWith (\(a,b) c -> (a,b,c)) regularFiles etags)
     return (FileTree (Trie.fromList infos) (T.pack f))
 
-staticResource :: StaticOptions -> FilePath -> IO (Resource s m)
+staticResource :: StaticOptions -> FilePath -> IO (Resource m)
 staticResource options p = staticResource' options <$> directoryTree p
 
-staticResource' :: StaticOptions -> FileTree -> Resource s m
+staticResource' :: StaticOptions -> FileTree -> Resource m
 staticResource' options FileTree{..} = defaultResource
     { allowedMethods = return [ HTTP.methodGet, HTTP.methodHead ]
     , resourceExists = getFileInfo >> return True
@@ -137,7 +137,7 @@ staticResource' options FileTree{..} = defaultResource
         return [ (mediaType, response)
                , ("application/octet-stream", response)]
     }
-    where getFileInfo :: Handler s m FileInfo
+    where getFileInfo :: Handler m FileInfo
           getFileInfo = do
             dispath <- dispatchPath
             let key = encodeUtf8 (T.intercalate "/" (root:dispath))
@@ -146,7 +146,7 @@ staticResource' options FileTree{..} = defaultResource
                 (Just r) -> return r
                 Nothing -> halt HTTP.status404
 
-addNoCacheHeaders :: Handler s m ()
+addNoCacheHeaders :: Handler m ()
 addNoCacheHeaders = do
     addResponseHeader (HTTP.hCacheControl, "no-cache, no-store, must-revalidate")
     addResponseHeader ("Pragma", "no-cache")

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -25,9 +25,6 @@ module Airship.Types
     , runWebmachine
     , request
     , requestTime
-    , getState
-    , putState
-    , modifyState
     , getResponseHeaders
     , getResponseBody
     , params
@@ -152,31 +149,30 @@ data Response m = Response { _responseStatus     :: Status
                            , _responseBody       :: ResponseBody m
                            }
 
-data ResponseState s m = ResponseState { stateUser      :: s
-                                       , stateHeaders   :: ResponseHeaders
-                                       , stateBody      :: ResponseBody m
-                                       , _params        :: HashMap Text Text
-                                       , _dispatchPath   :: [Text]
-                                       }
+data ResponseState m = ResponseState { stateHeaders   :: ResponseHeaders
+                                     , stateBody      :: ResponseBody m
+                                     , _params        :: HashMap Text Text
+                                     , _dispatchPath  :: [Text]
+                                     }
 
 type Trace = [Text]
 
-newtype Webmachine s m a =
-    Webmachine { getWebmachine :: EitherT (Response m) (RWST (RequestReader m) Trace (ResponseState s m) m) a }
+newtype Webmachine m a =
+    Webmachine { getWebmachine :: EitherT (Response m) (RWST (RequestReader m) Trace (ResponseState m) m) a }
         deriving (Functor, Applicative, Monad, MonadIO, MonadBase b,
                   MonadReader (RequestReader m),
                   MonadWriter Trace,
-                  MonadState (ResponseState s m))
+                  MonadState (ResponseState m))
 
-instance MonadTrans (Webmachine s) where
+instance MonadTrans Webmachine where
     lift = Webmachine . EitherT . (>>= return . Right) . lift
 
-newtype StMWebmachine s m a = StMWebmachine {
-      unStMWebmachine :: StM (EitherT (Response m) (RWST (RequestReader m) Trace (ResponseState s m) m)) a
+newtype StMWebmachine m a = StMWebmachine {
+      unStMWebmachine :: StM (EitherT (Response m) (RWST (RequestReader m) Trace (ResponseState m) m)) a
     }
 
-instance MonadBaseControl b m => MonadBaseControl b (Webmachine s m) where
-  type StM (Webmachine s m) a = StMWebmachine s m a
+instance MonadBaseControl b m => MonadBaseControl b (Webmachine m) where
+  type StM (Webmachine m) a = StMWebmachine m a
   liftBaseWith f = Webmachine
                      $ liftBaseWith
                      $ \g' -> f
@@ -185,68 +181,53 @@ instance MonadBaseControl b m => MonadBaseControl b (Webmachine s m) where
   restoreM = Webmachine . restoreM . unStMWebmachine
 
 -- | A convenience synonym that writes the @Monad@ type constraint for you.
-type Handler s m a = Monad m => Webmachine s m a
+type Handler m a = Monad m => Webmachine m a
 
 -- Functions inside the Webmachine Monad -------------------------------------
 ------------------------------------------------------------------------------
 
 -- | Returns the 'Request' that this 'Handler' is currently processing.
-request :: Handler s m (Request m)
+request :: Handler m (Request m)
 request = _request <$> ask
 
 -- | Returns the bound routing parameters extracted from the routing system (see "Airship.Route").
-params :: Handler s m (HashMap Text Text)
+params :: Handler m (HashMap Text Text)
 params = _params <$> get
 
-dispatchPath :: Handler s m [Text]
+dispatchPath :: Handler m [Text]
 dispatchPath = _dispatchPath <$> get
 
 -- | Returns the time at which this request began processing.
-requestTime :: Handler s m UTCTime
+requestTime :: Handler m UTCTime
 requestTime = _now <$> ask
 
--- | Returns the user state (of type @s@) in the provided @'Handler' s m@.
-getState :: Handler s m s
-getState = stateUser <$> get
-
--- | Sets the user state.
-putState :: s -> Handler s m ()
-putState s = modify updateState
-    where updateState rs = rs {stateUser = s}
-
--- | Applies the provided function to the user state.
-modifyState :: (s -> s) -> Handler s m ()
-modifyState f = modify modifyState'
-    where modifyState' rs@ResponseState{stateUser=uState} =
-                                        rs {stateUser = f uState}
-
 -- | Returns the 'ResponseHeaders' stored in the current 'Handler'.
-getResponseHeaders :: Handler s m ResponseHeaders
+getResponseHeaders :: Handler m ResponseHeaders
 getResponseHeaders = stateHeaders <$> get
 
 -- | Returns the current 'ResponseBody' that this 'Handler' is storing.
-getResponseBody :: Handler s m (ResponseBody m)
+getResponseBody :: Handler m (ResponseBody m)
 getResponseBody = stateBody <$> get
 
 -- | Given a new 'ResponseBody', replaces the stored body with the new one.
-putResponseBody :: ResponseBody m -> Handler s m ()
+putResponseBody :: ResponseBody m -> Handler m ()
 putResponseBody b = modify updateState
     where updateState rs = rs {stateBody = b}
 
 -- | Stores the provided 'ByteString' as the responseBody. This is a shortcut for
 -- creating a response body with a 'ResponseBuilder' and a bytestring 'Builder'.
-putResponseBS :: ByteString -> Handler s m ()
+putResponseBS :: ByteString -> Handler m ()
 putResponseBS bs = putResponseBody $ ResponseBuilder $ fromByteString bs
 
 -- | Immediately halts processing with the provided 'Status' code.
 -- The contents of the 'Handler''s response body will be streamed back to the client.
 -- This is a shortcut for constructing a 'Response' with 'getResponseHeaders' and 'getResponseBody'
 -- and passing that response to 'finishWith'.
-halt :: Status -> Handler m s a
+halt :: Status -> Handler m a
 halt status = finishWith =<< Response <$> pure status <*> getResponseHeaders <*> getResponseBody
 
 -- | Immediately halts processing and writes the provided 'Response' back to the client.
-finishWith :: Response m -> Handler s m a
+finishWith :: Response m -> Handler m a
 finishWith = Webmachine . left
 
 -- | The @#>@ operator provides syntactic sugar for the construction of association lists.
@@ -274,14 +255,14 @@ k #> v = tell [(k, v)]
 both :: Either a a -> a
 both = either id id
 
-eitherResponse :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request m -> s -> Handler s m (Response m) -> m (Response m, Trace)
-eitherResponse reqDate reqParams dispatched req s resource = do
-    (e, trace) <- runWebmachine reqDate reqParams dispatched req s resource
+eitherResponse :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request m -> Handler m (Response m) -> m (Response m, Trace)
+eitherResponse reqDate reqParams dispatched req resource = do
+    (e, trace) <- runWebmachine reqDate reqParams dispatched req resource
     return (both e, trace)
 
-runWebmachine :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request m -> s -> Handler s m a -> m (Either (Response m) a, Trace)
-runWebmachine reqDate reqParams dispatched req s w = do
-    let startingState = ResponseState s [] Empty reqParams dispatched
+runWebmachine :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request m -> Handler m a -> m (Either (Response m) a, Trace)
+runWebmachine reqDate reqParams dispatched req w = do
+    let startingState = ResponseState [] Empty reqParams dispatched
         requestReader = RequestReader reqDate req
     (e, _, t) <- runRWST (runEitherT (getWebmachine w)) requestReader startingState
     return (e, t)


### PR DESCRIPTION
I've been discussing this with @reiddraper over email. Opening a PR just in case any one else is interested or wanted to jump in.

The upside of this change is that you can have per-resource states and other nice things.

``` haskell
fooResource :: Resource (StateT State1 m)
barResource :: Resource (StateT State2 m)

myRoutes :: RoutingSpec IO ()
myRoutes = do
    "foo" #> hoistResource (flip evalStateT state1) fooResource
    "bar" #> hoistResource (flip evalStateT state2) barResource
```

The big downside is that both the parameterised `Request` and `ResponseBody` are difficult to support because they're contra-variant, and so I've had to remove them. I have a slightly different branch where I've added an extra type parameter to work around this, but I'm not convinced it's worth the pain.

https://github.com/helium/airship/compare/master...ambiata:topic/remove-state

Suggestions welcome.
