### PR TITLE
Remove MFunctor but provide runner for resourceToWai

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -131,4 +131,4 @@ main = do
     mvar <- newMVar HM.empty
     let s = State mvar
     putStrLn "Listening on port 3000"
-    runSettings settings (resourceToWai defaultAirshipConfig (hoist (flip evalStateT s) routes) resource404)
+    runSettings settings (resourceToWaiT defaultAirshipConfig (flip evalStateT s) routes resource404)

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -4,6 +4,7 @@ module Airship.Helpers
     , redirectTemporarily
     , redirectPermanently
     , resourceToWai
+    , resourceToWaiT
     ) where
 
 import           Airship.Internal.Helpers

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -79,13 +79,18 @@ toWaiResponse Response{..} cfg trace quip =
 
 -- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
 resourceToWai :: AirshipConfig -> RoutingSpec IO () -> Resource IO -> Wai.Application
-resourceToWai cfg routes resource404 req respond = do
+resourceToWai cfg routes resource404 =
+  resourceToWaiT cfg id routes resource404
+
+-- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
+resourceToWaiT :: Monad m => AirshipConfig -> (forall a. m a -> IO a) -> RoutingSpec m () -> Resource m -> Wai.Application
+resourceToWaiT cfg run routes resource404 req respond = do
     let routeMapping = runRouter routes
         pInfo = Wai.pathInfo req
         (resource, (params', matched)) = route routeMapping pInfo resource404
     nowTime <- getCurrentTime
     quip <- getQuip
-    (response, trace) <- eitherResponse nowTime params' matched req (flow resource)
+    (response, trace) <- run $ eitherResponse nowTime params' matched req (flow resource)
     respond (toWaiResponse response cfg (traceHeader trace) quip)
 
 getQuip :: IO ByteString

--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -16,8 +16,7 @@ import Data.HashMap.Strict (HashMap, insert)
 import           Control.Applicative
 #endif
 import Control.Monad.Identity
-import Control.Monad.Morph
-import Control.Monad.Writer (Writer, WriterT (..), execWriter, runWriterT)
+import Control.Monad.Writer (Writer, WriterT (..), execWriter)
 import Control.Monad.Writer.Class (MonadWriter)
 
 import Data.String (IsString, fromString)
@@ -80,12 +79,6 @@ star = Route [RestUnbound]
 --
 newtype RoutingSpec m a = RoutingSpec { getRouter :: Writer [(Route, Resource m)] a }
     deriving (Functor, Applicative, Monad, MonadWriter [(Route, Resource m)])
-
-instance MFunctor RoutingSpec where
-  hoist nat (RoutingSpec r) = RoutingSpec $
-    let Identity (a, w) = (runWriterT r)
-    in WriterT . Identity . (,) a $ fmap (\(ro, re) -> (ro, hoistResource nat re)) w
-
 
 route :: [(Route, a)] -> [Text] -> a -> (a, (HashMap Text Text, [Text]))
 route routes pInfo resource404 = foldr' (matchRoute pInfo) (resource404, (mempty, mempty)) routes

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -33,7 +33,6 @@ module Airship.Types
     , halt
     , finishWith
     , (#>)
-    , hoist
     ) where
 
 import Blaze.ByteString.Builder (Builder)
@@ -51,7 +50,7 @@ import Control.Monad.Morph
 import Control.Monad.Reader.Class (MonadReader, ask)
 import Control.Monad.State.Class (MonadState, get, modify)
 import Control.Monad.Trans.Control (MonadBaseControl(..))
-import Control.Monad.Trans.Either (EitherT(..), mapEitherT, runEitherT, left)
+import Control.Monad.Trans.Either (EitherT(..), runEitherT, left)
 import Control.Monad.Trans.RWS.Strict (RWST(..), runRWST)
 import Control.Monad.Writer.Class (MonadWriter, tell)
 import Data.ByteString.Char8
@@ -91,7 +90,6 @@ etagToByteString (Strong bs) = "\"" <> bs <> "\""
 etagToByteString (Weak bs) = "W/\"" <> bs <> "\""
 
 -- | Basically Wai's unexported 'Response' type.
--- Was previously generalized to any monad, but that makes it impossible to use MFunctor.
 data ResponseBody
     = ResponseFile FilePath (Maybe Wai.FilePart)
     | ResponseBuilder Builder
@@ -125,9 +123,6 @@ newtype Webmachine m a =
 
 instance MonadTrans Webmachine where
     lift = Webmachine . EitherT . (>>= return . Right) . lift
-
-instance MFunctor Webmachine where
-  hoist nat = Webmachine . mapEitherT (hoist nat) . getWebmachine
 
 newtype StMWebmachine m a = StMWebmachine {
       unStMWebmachine :: StM (EitherT Response (RWST RequestReader Trace ResponseState m)) a


### PR DESCRIPTION
I am so so so sorry about this. :( Unfortunately the example works because it's sharing an MVar, but it's running each handler.

First thing this weekend I'm going to add a test to make sure this doesn't regress again.

As part of this PR it's probably also possible to add back in some, if not all, or the parameterized `Request` and `ResponseBody` (not sure about that last one).

I suspect the `forall a. m a -> n a` could also be a little more specific on the return type to all errors/responses to be defined (see examples below). I was keen just to get this up, but will rethink later today.

Prior art:
- https://github.com/scotty-web/scotty/blob/c05bcdd0e401019bac654ed5081a498a6fed97fd/Web/Scotty/Trans.hs#L65
- https://github.com/webcrank/webcrank.hs/blob/master/src/Webcrank/Internal/HandleRequest.hs#L47
