### PR TITLE
Bring back parameterized request (but not response)

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -35,10 +35,10 @@ import           Network.Wai.Handler.Warp           (defaultSettings,
 -- Helpers
 -- ***************************************************************************
 
-getBody :: MonadIO m => Webmachine m LB.ByteString
+getBody :: Monad m => Webmachine m LB.ByteString
 getBody = do
     req <- request
-    liftIO (entireRequestBody req)
+    lift (entireRequestBody req)
 
 readBody :: MonadIO m => Webmachine m Integer
 readBody = read . unpack <$> getBody

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -3,6 +3,7 @@ module Airship.Helpers
     , contentTypeMatches
     , redirectTemporarily
     , redirectPermanently
+    , fromWaiRequest
     , resourceToWai
     , resourceToWaiT
     ) where

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -8,6 +8,7 @@ module Airship.Internal.Helpers where
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
+import           Control.Monad.IO.Class    (MonadIO, liftIO)
 import           Data.ByteString           (ByteString)
 import qualified Data.ByteString.Lazy      as LazyBS
 import           Data.Maybe
@@ -35,8 +36,8 @@ import           Airship.Types
 -- @www-form-urlencoded@ or @multipart/form-data@ to return a
 -- list of parameter names and values and a list of uploaded
 -- files and their information.
-parseFormData :: Request -> IO ([Param], [File LazyBS.ByteString])
-parseFormData r = parseRequestBody lbsBackEnd r
+parseFormData :: Request IO -> IO ([Param], [File LazyBS.ByteString])
+parseFormData r = parseRequestBody lbsBackEnd (waiRequest r)
 
 -- | Returns @True@ if the request's @Content-Type@ header is one of the
 -- provided media types. If the @Content-Type@ header is not present,
@@ -59,6 +60,25 @@ redirectTemporarily location =
 redirectPermanently :: Monad m => ByteString -> Webmachine m a
 redirectPermanently location =
     addResponseHeader ("Location", location) >> halt HTTP.status301
+
+-- | Construct an Airship 'Request' from a WAI request.
+fromWaiRequest :: MonadIO m => Wai.Request -> Request m
+fromWaiRequest req = Request
+    { requestMethod = Wai.requestMethod req
+    , httpVersion = Wai.httpVersion req
+    , rawPathInfo = Wai.rawPathInfo req
+    , rawQueryString = Wai.rawQueryString req
+    , requestHeaders = Wai.requestHeaders req
+    , isSecure = Wai.isSecure req
+    , remoteHost = Wai.remoteHost req
+    , pathInfo = Wai.pathInfo req
+    , queryString = Wai.queryString req
+    , requestBody = liftIO $ Wai.requestBody req
+    , requestBodyLength = Wai.requestBodyLength req
+    , requestHeaderHost = Wai.requestHeaderHost req
+    , requestHeaderRange = Wai.requestHeaderRange req
+    , waiRequest = req
+    }
 
 toWaiResponse :: Response -> AirshipConfig -> ByteString -> ByteString -> Wai.Response
 toWaiResponse Response{..} cfg trace quip =
@@ -83,14 +103,15 @@ resourceToWai cfg routes resource404 =
   resourceToWaiT cfg id routes resource404
 
 -- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
-resourceToWaiT :: Monad m => AirshipConfig -> (forall a. m a -> IO a) -> RoutingSpec m () -> Resource m -> Wai.Application
+resourceToWaiT :: MonadIO m => AirshipConfig -> (forall a. m a -> IO a) -> RoutingSpec m () -> Resource m -> Wai.Application
 resourceToWaiT cfg run routes resource404 req respond = do
     let routeMapping = runRouter routes
         pInfo = Wai.pathInfo req
+        airshipReq = fromWaiRequest req
         (resource, (params', matched)) = route routeMapping pInfo resource404
     nowTime <- getCurrentTime
     quip <- getQuip
-    (response, trace) <- run $ eitherResponse nowTime params' matched req (flow resource)
+    (response, trace) <- run $ eitherResponse nowTime params' matched airshipReq (flow resource)
     respond (toWaiResponse response cfg (traceHeader trace) quip)
 
 getQuip :: IO ByteString

--- a/test/unit/test.hs
+++ b/test/unit/test.hs
@@ -3,7 +3,9 @@
 module Main where
 
 import Airship
-import Control.Concurrent
+import Control.Monad.Trans.State.Strict (State, evalState, get, put)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LB
 import Data.ByteString (ByteString)
 
 import Test.Tasty
@@ -22,16 +24,27 @@ exampleTests :: TestTree
 exampleTests = testGroup "ExampleTests"
   [ bodyTest ]
 
+type RequestState = State [ByteString]
+
 bodyChunks :: [ByteString]
 bodyChunks = ["one", "two", "three", "four", "five"]
 
-bodyChunksIO :: IO (IO ByteString)
-bodyChunksIO = do
-    v <- newMVar bodyChunks
-    return $ modifyMVar v (\l -> return $ case l of { [] -> ([], ""); h : t -> (t, h) })
+nextBody :: RequestState ByteString
+nextBody = do
+    s <- get
+    if null s
+        then return BS.empty
+        else do
+            let (h:tl) = s
+            put tl
+            return h
 
 bodyTest :: TestTree
-bodyTest = testCase "entireRequestBody returns the body in the correct order" $ do
-    nextBody <- bodyChunksIO
-    b <- entireRequestBody defaultRequest { requestBody = nextBody }
-    b @?= "onetwothreefourfive"
+bodyTest = testCase "entireRequestBody returns the body in the correct order" bodyTest'
+    where bodyTest' = evalState state bodyChunks @?= "onetwothreefourfive"
+          state :: RequestState LB.ByteString
+          state = entireRequestBody req
+          req = defRequest { requestBody = nextBody }
+          -- for some reason this type signature seems to be necessary
+          defRequest :: Request RequestState
+          defRequest = defaultRequest


### PR DESCRIPTION
I have another suggestion which I'll raise in another PR. This version is half of the original code.

Response is a little harder due to the contravariant problem (I think). If anyone is interested there's a separate branch with both request/response (but not compiling)

https://github.com/helium/airship/compare/ea7132a...topic/parameterized-request-response
