### PR TITLE
Bring back parameterized request reader with just body

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -17,7 +17,6 @@ import           Control.Applicative                ((<$>))
 import           Control.Concurrent.MVar
 import           Control.Monad.State                hiding (State)
 
-import qualified Data.ByteString.Lazy               as LB
 import           Data.ByteString.Lazy.Char8         (unpack)
 import           Data.HashMap.Strict                (HashMap)
 import qualified Data.HashMap.Strict                as HM
@@ -35,13 +34,8 @@ import           Network.Wai.Handler.Warp           (defaultSettings,
 -- Helpers
 -- ***************************************************************************
 
-getBody :: MonadIO m => Webmachine m LB.ByteString
-getBody = do
-    req <- request
-    liftIO (entireRequestBody req)
-
 readBody :: MonadIO m => Webmachine m Integer
-readBody = read . unpack <$> getBody
+readBody = read . unpack <$> entireRequestBody
 
 routingParam :: Monad m => Text -> Webmachine m Text
 routingParam t = do

--- a/test/unit/test.hs
+++ b/test/unit/test.hs
@@ -3,7 +3,9 @@
 module Main where
 
 import Airship
-import Control.Concurrent
+import Control.Monad.Trans.State.Strict (State, evalState, get, put)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LB
 import Data.ByteString (ByteString)
 
 import Test.Tasty
@@ -22,16 +24,23 @@ exampleTests :: TestTree
 exampleTests = testGroup "ExampleTests"
   [ bodyTest ]
 
+type RequestState = State [ByteString]
+
 bodyChunks :: [ByteString]
 bodyChunks = ["one", "two", "three", "four", "five"]
 
-bodyChunksIO :: IO (IO ByteString)
-bodyChunksIO = do
-    v <- newMVar bodyChunks
-    return $ modifyMVar v (\l -> return $ case l of { [] -> ([], ""); h : t -> (t, h) })
+nextBody :: RequestState ByteString
+nextBody = do
+    s <- get
+    if null s
+        then return BS.empty
+        else do
+            let (h:tl) = s
+            put tl
+            return h
 
 bodyTest :: TestTree
-bodyTest = testCase "entireRequestBody returns the body in the correct order" $ do
-    nextBody <- bodyChunksIO
-    b <- entireRequestBody defaultRequest { requestBody = nextBody }
-    b @?= "onetwothreefourfive"
+bodyTest = testCase "entireRequestBody returns the body in the correct order" bodyTest'
+    where bodyTest' = evalState state bodyChunks @?= "onetwothreefourfive"
+          state :: RequestState LB.ByteString
+          state = entireRequestBody' nextBody


### PR DESCRIPTION
Alternative to https://github.com/helium/airship/pull/59, but avoids having a full duplicate `Request`.

This was just me playing around, happy to clean up further if people have concerns. FWIW I'm not actually pushing this idea - I think I'm happy just having a `MonadIO m` when you need to read `requestBody`, but not trying to push that on anyone else. :)
