### PR TITLE
Allow resourceToWaiT to return wai Response

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -131,4 +131,4 @@ main = do
     mvar <- newMVar HM.empty
     let s = State mvar
     putStrLn "Listening on port 3000"
-    runSettings settings (resourceToWaiT defaultAirshipConfig (flip evalStateT s) routes resource404)
+    runSettings settings (resourceToWaiT defaultAirshipConfig (const $ flip evalStateT s) routes resource404)

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -83,15 +83,16 @@ resourceToWai cfg routes resource404 =
   resourceToWaiT cfg id routes resource404
 
 -- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
-resourceToWaiT :: Monad m => AirshipConfig -> (forall a. m a -> IO a) -> RoutingSpec m () -> Resource m -> Wai.Application
+resourceToWaiT :: Monad m => AirshipConfig -> (m Wai.Response -> IO Wai.Response) -> RoutingSpec m () -> Resource m -> Wai.Application
 resourceToWaiT cfg run routes resource404 req respond = do
     let routeMapping = runRouter routes
         pInfo = Wai.pathInfo req
         (resource, (params', matched)) = route routeMapping pInfo resource404
     nowTime <- getCurrentTime
     quip <- getQuip
-    (response, trace) <- run $ eitherResponse nowTime params' matched req (flow resource)
-    respond (toWaiResponse response cfg (traceHeader trace) quip)
+    (=<<) respond . run $ do
+      (response, trace) <- eitherResponse nowTime params' matched req (flow resource)
+      return $ toWaiResponse response cfg (traceHeader trace) quip
 
 getQuip :: IO ByteString
 getQuip = do


### PR DESCRIPTION
As mentioned previously this is how [scotty](https://github.com/scotty-web/scotty/blob/c05bcdd0e401019bac654ed5081a498a6fed97fd/Web/Scotty/Trans.hs#L101) works. For us it's a way to convert `Db Response` to `IO Response` where we can convert resulting to a different `Response`. With the natural transformation this isn't possible and limits the use of `run`.

Thoughts?
