### PR TITLE
Add readParam helper for reading values from HTTP params.

### DIFF
--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -5,6 +5,8 @@ module Airship.Helpers
     , redirectPermanently
     , resourceToWai
     , resourceToWaiT
+    , readParam
+    , readParamMaybe
     ) where
 
 import           Airship.Internal.Helpers


### PR DESCRIPTION
Jared and I were both a little bogged down by Airship's lack of a helper
for slurping and reading values from a request's HTTP params. This is my
crack at defining such a function:

`readParam :: Read a => Text -> Handler s m a -> Handler s m a`

Add readParamMaybe and fix typos.

Update the documentation.

Basically just a cherry-pick and cleanup of @patrickt's changes here https://github.com/helium/airship/pull/44
