### PR TITLE
Specify version ranges to pacify stackage.

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -42,15 +42,15 @@ library
                       , case-insensitive
                       , cryptohash == 0.11.6.*
                       , directory
-                      , either >= 4.3 && < 4.5
+                      , either >= 4.3 && < 4.6
                       , filepath >= 1.3 && < 1.5
                       , http-date
                       , http-media
                       , http-types == 0.9.*
                       , lifted-base == 0.2.*
                       , microlens
-                      , mime-types == 0.1.0.*
                       , monad-control >= 1.0
+                      , mime-types == 0.1.0.*
                       , mmorph == 1.0.*
                       , mtl
                       , network
@@ -74,8 +74,8 @@ test-suite unit
                , airship
                , text             == 1.2.*
                , bytestring       >= 0.9.1   && < 0.11
-               , tasty            == 0.10.*
-               , tasty-quickcheck == 0.8.3.*
+               , tasty            >= 0.10.1  && < 0.12
+               , tasty-quickcheck >= 0.8.3   && < 0.8.5
                , tasty-hunit        >= 0.9.1 && < 0.10
                , transformers
                , wai == 3.0.*


### PR DESCRIPTION
Attempting to pacify stockage build errors without completely removing upper bounds.
