### PR TITLE
Widen http-types range and put custom headers back in.

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -48,7 +48,7 @@ library
                       , filepath >= 1.3 && < 1.5
                       , http-date
                       , http-media
-                      , http-types == 0.9.*
+                      , http-types >= 0.8 && <0.10
                       , lifted-base == 0.2.*
                       , microlens
                       , monad-control >= 1.0


### PR DESCRIPTION
Some projects can't handle newer versions of http-types.

@reiddraper downgrading http-types to make stackage happy.
https://github.com/fpco/stackage/pull/970
