### PR TITLE
Expose appendRequestPath helper.

### DIFF
--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -5,6 +5,7 @@ module Airship.Helpers
     , redirectPermanently
     , resourceToWai
     , resourceToWaiT
+    , appendRequestPath
     ) where
 
 import           Airship.Internal.Helpers

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -6,6 +6,7 @@
 
 module Airship.Internal.Decision
     ( flow
+    , appendRequestPath
     ) where
 
 import           Airship.Internal.Date (parseRfc1123Date, utcTimeToRfc1123)

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -3,7 +3,15 @@
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE RecordWildCards   #-}
 
-module Airship.Internal.Helpers where
+module Airship.Internal.Helpers
+    ( parseFormData
+    , contentTypeMatches
+    , redirectTemporarily
+    , redirectPermanently
+    , resourceToWai
+    , resourceToWaiT
+    , appendRequestPath
+    ) where
 
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative


### PR DESCRIPTION
I needed access to this behaviour so I could update the `"Location"` header for a PostCreate.

e.g.

``` haskell
Just a -> do
  s <- appendRequestPath [a]
  addResponseHeader (HTTP.hLocation, s)
```
