### PR TITLE
Introduce alternative Resource

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -21,6 +21,7 @@ library
   hs-source-dirs: src
   ghc-options:  -Wall
   exposed-modules:   Airship
+                   , Airship2
                    , Airship.Config
                    , Airship.Headers
                    , Airship.Helpers
@@ -30,6 +31,10 @@ library
                    , Airship.Resource.Route
                    , Airship.Resource.Static
                    , Airship.Resource.Wai
+                   , Airship.Resource2.Data
+                   , Airship.Resource2.Decision
+                   , Airship.Resource2.Route
+                   , Airship.Resource2.Wai
                    , Airship.Route
 
   other-modules:     Airship.Internal.Route
@@ -62,6 +67,7 @@ library
                       , old-locale
                       , random
                       , text
+                      , semigroups == 0.16.*
                       , time
                       , transformers
                       , transformers-base

--- a/airship.cabal
+++ b/airship.cabal
@@ -26,7 +26,10 @@ library
                    , Airship.Helpers
                    , Airship.Types
                    , Airship.Resource
+                   , Airship.Resource.Decision
+                   , Airship.Resource.Route
                    , Airship.Resource.Static
+                   , Airship.Resource.Wai
                    , Airship.Route
 
   other-modules:     Airship.Internal.Route

--- a/doc/versioning-apis.md
+++ b/doc/versioning-apis.md
@@ -28,7 +28,6 @@ json response.
     dirigibleResourceV1 :: (Applicative m, MonadIO m) => Resource State m
     dirigibleResourceV1 = defaultResource {
         allowedMethods = return [ HTTP.methodGet ]
-        , knownContentType = contentTypeMatches ["application/json"]
         , contentTypesProvided = return [("application/json", handleJsonV1)]
     }
 
@@ -36,7 +35,6 @@ json response.
     dirigibleResourceV2 :: (Applicative m, MonadIO m) => Resource State m
     dirigibleResourceV2 = defaultResource {
         allowedMethods = return [ HTTP.methodGet ]
-      , knownContentType = contentTypeMatches ["application/json"]
       , contentTypesProvided = return [("application/json", handleJsonV2)]
     }
 
@@ -64,7 +62,6 @@ Then within the resource we handle both versions.
     dirigibleResource :: (Applicative m, MonadIO m) => Resource State m
     dirigibleResource = defaultResource {
         allowedMethods = return [ HTTP.methodGet ]
-      , knownContentType = contentTypeMatches ["application/json"]
       , knownContentTypes = contentTypesProvided ["application/v1+json", "application/v2+json"]
       , contentTypesProvided = return [ ("application/v1+json", handleJsonV1)
                                       , ("application/v2+json", handleJsonV2)]

--- a/example/Basic.hs
+++ b/example/Basic.hs
@@ -63,7 +63,6 @@ accountResource = defaultResource
                               , HTTP.methodPost
                               , HTTP.methodPut
                               ]
-    , knownContentType = contentTypeMatches ["text/plain"]
 
     , contentTypesProvided = do
         let textAction = do

--- a/example/Basic2.hs
+++ b/example/Basic2.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Basic2 where
+
+import           Airship2
+
+import           Blaze.ByteString.Builder.Html.Utf8 (fromHtmlEscapedText)
+
+#if __GLASGOW_HASKELL__ < 710
+import           Control.Applicative                ((<$>))
+#endif
+import           Control.Concurrent.MVar
+import           Control.Monad.State                hiding (State)
+
+import qualified Data.ByteString.Lazy               as LB
+import           Data.ByteString.Lazy.Char8         (unpack)
+import           Data.HashMap.Strict                (HashMap)
+import qualified Data.HashMap.Strict                as HM
+import           Data.List.NonEmpty                 (NonEmpty (..))
+import           Data.Monoid                        ((<>))
+import           Data.Text                          (Text, pack)
+import           Data.Time.Clock
+
+import qualified Network.HTTP.Types                 as HTTP
+import           Network.Wai.Handler.Warp           (defaultSettings,
+                                                     runSettings, setHost,
+                                                     setPort)
+
+-- ***************************************************************************
+-- Helpers
+-- ***************************************************************************
+
+getBody :: MonadIO m => Webmachine m LB.ByteString
+getBody = do
+    req <- request
+    liftIO (entireRequestBody req)
+
+readBody :: MonadIO m => Webmachine m Integer
+readBody = read . unpack <$> getBody
+
+newtype State = State { _getState :: MVar (HashMap Text Integer) }
+
+data Plain = Plain
+
+
+resourceWithBody :: (MonadIO m, MonadState State m) => Text -> Resource m
+resourceWithBody t =
+  resource
+    resourceDesc { contentTypesProvided = ("text/plain", Plain) :| [] } .
+    return $ Right $ \_ accept -> do
+      now <- liftIO getCurrentTime
+      return . ResourceExists (CacheData (Just now) (Just $ Strong "abc123")) $ \case
+        ROther run -> case accept of
+          Plain -> run . ok $ escapedResponse t
+        _ -> lift serverError
+
+accountResource :: (MonadIO m, MonadState State m) => Resource m
+accountResource = do
+    let rd = resourceDesc {
+            allowedMethods = [HTTP.methodGet, HTTP.methodHead, HTTP.methodPost, HTTP.methodPut]
+          , contentTypesAccepted = ("text/plain", Plain) :| []
+          , contentTypesProvided = ("text/plain", Plain) :| []
+          }
+    resource rd . return . Right $ \_ accept -> do
+        accountName <- lookupParam "name"
+        s <- lift get
+        m <- liftIO (readMVar (_getState s))
+        now <- liftIO getCurrentTime
+        let cache = noCacheData { cacheModified = Just now }
+        return $ case HM.lookup accountName m of
+            Nothing ->
+                ResourceNotFound $ \case
+                    MPost run ->
+                        run MPostNotFound
+                    MOther run ->
+                        run MOtherNotFound
+                    MPut run -> do
+                        val <- lift readBody
+                        liftIO (modifyMVar_ (_getState s) (return . HM.insert accountName val))
+                        run . MPutOk cache . ok $ Empty
+            Just val ->
+                ResourceExists cache $ \case
+                    ROther run -> case accept of
+                        Plain ->
+                            run . ok $ ResponseBuilder (fromHtmlEscapedText (pack (show val) <> "\n"))
+                    RPut run -> case accept of
+                        Plain -> do
+                            val' <- lift readBody
+                            liftIO (modifyMVar_ (_getState s) (return . HM.insert accountName val'))
+                            run . RPutOk . ok $ Empty
+                    -- POST'ing to this resource adds the integer to the current value
+                    RPost run -> case accept of
+                        Plain -> do
+                            val' <- lift readBody
+                            liftIO (modifyMVar_ (_getState s) (return . HM.insertWith (+) accountName val'))
+                            run . RPostOk . ok $ Empty
+                    RDelete _ -> lift serverError
+
+resource404 :: Monad m => Resource m
+resource404 = do
+  -- TODO The types now show that this wasn't used
+  let _response404 = escapedResponse "<html><head></head><body><h1>404 Not Found</h1></body></html>"
+  resource
+    resourceDesc { contentTypesProvided = ("text/html", ()) :| [] } .
+    return $ Right $ \_ _ ->
+      return . ResourceNotFound $ \case
+        MOther run -> run MOtherNotFound
+        _ -> lift serverError
+
+myRoutes :: RoutingSpec (StateT State IO) ()
+myRoutes = do
+    root                        #> resourceWithBody "Just the root resource"
+    "account" </> var "name"    #> accountResource
+
+main :: IO ()
+main = do
+    let port = 3000
+        host = "127.0.0.1"
+        settings = setPort port (setHost host defaultSettings)
+
+    mvar <- newMVar HM.empty
+    let s = State mvar
+    putStrLn "Listening on port 3000"
+    runSettings settings (resourceToWaiT defaultAirshipConfig (const $ flip evalStateT s) myRoutes resource404)

--- a/example/Basic2.hs
+++ b/example/Basic2.hs
@@ -87,12 +87,12 @@ accountResource = do
                         Plain ->
                             run . ok $ ResponseBuilder (fromHtmlEscapedText (pack (show val) <> "\n"))
                     RPut run -> do
-                        val' <- case accept of Plain -> lift readBody
+                        val' <- case contentType of Plain -> lift readBody
                         liftIO (modifyMVar_ (_getState s) (return . HM.insert accountName val'))
                         run . RPutOk . ok $ Empty
                     -- POST'ing to this resource adds the integer to the current value
                     RPost run -> do
-                        val' <- case accept of Plain -> lift readBody
+                        val' <- case contentType of Plain -> lift readBody
                         liftIO (modifyMVar_ (_getState s) (return . HM.insertWith (+) accountName val'))
                         run . RPostOk . ok $ Empty
                     RDelete _ ->

--- a/example/airship-example.cabal
+++ b/example/airship-example.cabal
@@ -27,6 +27,24 @@ executable              basic
                       , wai == 3.0.*
                       , warp == 3.0.*
 
+executable              basic2
+  main-is:              Basic2.hs
+  ghc-options:          -Wall -threaded -O2 -main-is Basic2
+  default-language:     Haskell2010
+  hs-source-dirs:     .
+  build-depends:        base >=4.7 && < 5
+                      , airship
+                      , blaze-builder >=0.3 && < 0.5
+                      , bytestring
+                      , http-types >= 0.7
+                      , mtl
+                      , semigroups == 0.16.*
+                      , text
+                      , time
+                      , unordered-containers
+                      , wai == 3.0.*
+                      , warp == 3.0.*
+
 executable            versions
   main-is:              Versions.hs
   ghc-options:          -Wall -threaded -O2 -main-is Versions

--- a/src/Airship.hs
+++ b/src/Airship.hs
@@ -2,17 +2,12 @@
 {-# LANGUAGE RankNTypes        #-}
 
 module Airship
-  ( module Airship.Config
-  , module Airship.Resource
-  , module Airship.Headers
-  , module Airship.Helpers
-  , module Airship.Route
-  , module Airship.Types
+  ( module X
   ) where
 
-import           Airship.Config
-import           Airship.Headers
-import           Airship.Helpers
-import           Airship.Resource
-import           Airship.Route
-import           Airship.Types
+import           Airship.Config as X
+import           Airship.Headers as X
+import           Airship.Helpers as X
+import           Airship.Resource as X
+import           Airship.Route as X
+import           Airship.Types as X

--- a/src/Airship.hs
+++ b/src/Airship.hs
@@ -9,5 +9,8 @@ import           Airship.Config as X
 import           Airship.Headers as X
 import           Airship.Helpers as X
 import           Airship.Resource as X
+import           Airship.Resource.Decision as X
+import           Airship.Resource.Route as X
+import           Airship.Resource.Wai as X
 import           Airship.Route as X
 import           Airship.Types as X

--- a/src/Airship/Headers.hs
+++ b/src/Airship/Headers.hs
@@ -3,9 +3,12 @@
 module Airship.Headers
     ( addResponseHeader
     , modifyResponseHeaders
+    , setResponseHeader
     ) where
 
 import Airship.Types (Webmachine, ResponseState(..))
+import Data.Function (on)
+import Data.List as DL
 import Control.Monad.State.Class (modify)
 import Network.HTTP.Types (ResponseHeaders, Header)
 
@@ -17,3 +20,7 @@ modifyResponseHeaders f = modify updateHeaders
 -- | Adds a given 'Header' to this handler's 'ResponseState'.
 addResponseHeader :: Monad m => Header -> Webmachine m ()
 addResponseHeader h = modifyResponseHeaders (h :)
+
+-- | Set a given 'Header' to this handler's 'ResponseState'.
+setResponseHeader :: Monad m => Header -> Webmachine m ()
+setResponseHeader s = modifyResponseHeaders $ (s :) . DL.deleteBy (on (==) fst) s

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -1,6 +1,5 @@
 module Airship.Helpers
     ( parseFormData
-    , contentTypeMatches
     , redirectTemporarily
     , redirectPermanently
     , appendRequestPath

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -3,8 +3,6 @@ module Airship.Helpers
     , contentTypeMatches
     , redirectTemporarily
     , redirectPermanently
-    , resourceToWai
-    , resourceToWaiT
     , appendRequestPath
     , lookupParam
     , lookupParam'

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -206,12 +206,15 @@ b06 validC = do
         then return ()
         else lift $ halt HTTP.status501
 
-b05 :: Monad m => Bool -> FlowStateT m ()
+b05 :: Monad m => [(MediaType, a)] -> FlowStateT m (Maybe a)
 b05 known = do
     trace "b05"
-    if known
-        then return ()
-        else lift $ halt HTTP.status415
+    headers <- requestHeaders <$> lift request
+    case lookup HTTP.hContentType headers of
+        Nothing -> return Nothing
+        Just t -> case mapAcceptMedia known t of
+            Just a -> return $ Just a
+            Nothing -> lift $ halt HTTP.status415
 
 b04 :: Monad m => Bool-> FlowStateT m ()
 b04 large = do

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -1,22 +1,19 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Airship.Internal.Decision
-    ( flow
-    , appendRequestPath
-    ) where
+module Airship.Internal.Decision where
 
 import           Airship.Internal.Date (parseRfc1123Date, utcTimeToRfc1123)
-import           Airship.Headers (addResponseHeader)
-import           Airship.Types ( Response(..)
+import           Airship.Headers (addResponseHeader, setResponseHeader)
+import           Airship.Types ( CacheData(..)
+                               , Location(..)
                                , ResponseBody(..)
                                , Webmachine
                                , etagToByteString
-                               , getResponseBody
-                               , getResponseHeaders
                                , halt
                                , pathInfo
                                , putResponseBody
@@ -25,19 +22,18 @@ import           Airship.Types ( Response(..)
                                , requestMethod
                                , requestTime )
 
-import           Airship.Resource(Resource(..), PostResponse(..))
 import           Airship.Internal.Parsers (parseEtagList)
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative ((<$>))
 #endif
-import           Control.Monad (when)
+import           Control.Monad ((>=>), unless, when)
 import           Control.Monad.Trans (lift)
-import           Control.Monad.Trans.State.Strict (StateT(..), evalStateT,
-                                                   get, modify)
+import           Control.Monad.Trans.State.Strict (StateT(..))
 import           Control.Monad.Writer.Class (tell)
 
 import           Blaze.ByteString.Builder (toByteString)
-import           Data.Maybe (isJust)
+import           Data.Foldable (traverse_)
+import qualified Data.Foldable as F
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
 import           Data.ByteString                  (ByteString, intercalate)
@@ -71,18 +67,8 @@ hIfNoneMatch = "If-None-Match"
 -- tree
 ------------------------------------------------------------------------------
 
-data FlowState m = FlowState
-    { _contentType :: Maybe (MediaType, Webmachine m ResponseBody) }
+type FlowStateT m = StateT () (Webmachine m)
 
-type FlowStateT m a = StateT (FlowState m) (Webmachine m) a
-
-type Flow m = Resource m -> FlowStateT m Response
-
-initFlowState :: FlowState m
-initFlowState = FlowState Nothing
-
-flow :: Monad m => Resource m -> Webmachine m Response
-flow r = evalStateT (b13 r) initFlowState
 
 trace :: Monad m => Text -> FlowStateT m ()
 trace t = lift $ tell [t]
@@ -93,22 +79,19 @@ trace t = lift $ tell [t]
 
 newtype IfMatch = IfMatch ByteString
 newtype IfNoneMatch = IfNoneMatch ByteString
+newtype IfModifiedSinceHeader = IfModifiedSinceHeader ByteString
+newtype IfModifiedSince = IfModifiedSince UTCTime
+newtype IfUnmodifiedSinceHeader = IfUnmodifiedSinceHeader ByteString
+newtype IfUnmodifiedSince = IfUnmodifiedSince UTCTime
+
+newtype AcceptHeader = AcceptHeader ByteString
+newtype AcceptLanguage = AcceptLanguage ByteString
+newtype AcceptCharset = AcceptCharset ByteString
+newtype AcceptEncoding = AcceptEncoding ByteString
 
 ------------------------------------------------------------------------------
 -- Decision Helpers
 ------------------------------------------------------------------------------
-
-negotiateContentTypesAccepted :: Monad m => Resource m -> FlowStateT m ()
-negotiateContentTypesAccepted Resource{..} = do
-    req <- lift request
-    accepted <- lift contentTypesAccepted
-    let reqHeaders = requestHeaders req
-        result = do
-            cType <- lookup HTTP.hContentType reqHeaders
-            mapContentMedia accepted cType
-    case result of
-        (Just process) -> lift process
-        Nothing -> lift $ halt HTTP.status415
 
 appendRequestPath :: Monad m => [Text] -> Webmachine m ByteString
 appendRequestPath ts = do
@@ -124,52 +107,42 @@ requestHeaderDate headerName = do
         parsedDate = dateHeader >>= parseRfc1123Date
     return parsedDate
 
-writeCacheTags :: Monad m => Resource m -> FlowStateT m ()
-writeCacheTags Resource{..} = lift $ do
-    etag <- generateETag
-    case etag of
-       Nothing -> return ()
-       Just t  -> addResponseHeader ("ETag", etagToByteString t)
-    modified <- lastModified
-    case modified of
-       Nothing -> return ()
-       Just d  -> addResponseHeader ("Last-Modified", utcTimeToRfc1123 d)
+preconditions :: Monad m => CacheData -> FlowStateT m ()
+preconditions (CacheData modified' _) = do
+    ifMatch'
+    ifUnmodifiedSince' modified'
+    ifNoneMatch'
+    ifModifiedSince' modified'
 
-------------------------------------------------------------------------------
--- Type definitions for all decision nodes
-------------------------------------------------------------------------------
+ifMatch' :: Monad m => FlowStateT m ()
+ifMatch' =
+    g08 >>= traverse_ (g09 >=> traverse_ g11)
 
-b13, b12, b11, b10, b09, b08, b07, b06, b05, b04, b03 :: Monad m => Flow  m
-c04, c03 :: Monad m => Flow  m
-d05, d04 :: Monad m => Flow  m
-e06, e05 :: Monad m => Flow  m
-f07, f06 :: Monad m => Flow  m
-g11, g09 :: Monad m => IfMatch -> Flow m
-g08, g07 :: Monad m => Flow  m
-h12, h11, h10, h07 :: Monad m => Flow  m
-i13 :: Monad m => IfNoneMatch -> Flow m
-i12, i07, i04 :: Monad m => Flow  m
-j18 :: Monad m => Flow  m
-k13 :: Monad m => IfNoneMatch -> Flow m
-k07, k05 :: Monad m => Flow  m
-l17, l15, l14, l13, l07, l05 :: Monad m => Flow  m
-m20, m16, m07, m05 :: Monad m => Flow  m
-n16, n11, n05 :: Monad m => Flow  m
-o20, o18, o16, o14 :: Monad m => Flow  m
-p11, p03 :: Monad m => Flow  m
+ifUnmodifiedSince' :: Monad m => Maybe UTCTime -> FlowStateT m ()
+ifUnmodifiedSince' lastModified =
+    h10 >>= traverse_ (h11 >=> traverse_ (h12 lastModified))
+
+ifNoneMatch' :: Monad m => FlowStateT m ()
+ifNoneMatch' =
+    i12 >>= traverse_ (i13 >=> maybe j18 (k13 >=> flip unless j18))
+
+ifModifiedSince' :: Monad m => Maybe UTCTime -> FlowStateT m ()
+ifModifiedSince' lastModified = do
+    l13 >>= traverse_ (l14 >=> traverse_ (\ims -> l15 ims >>= flip unless (l17 lastModified ims)))
 
 ------------------------------------------------------------------------------
 -- B column
 ------------------------------------------------------------------------------
 
-b13 r@Resource{..} = do
+b13 :: Monad m => Bool -> FlowStateT m ()
+b13 available = do
     trace "b13"
-    available <- lift serviceAvailable
     if available
-        then b12 r
+        then return ()
         else lift $ halt HTTP.status503
 
-b12 r@Resource{..} = do
+b12 :: Monad m => FlowStateT m ()
+b12 = do
     trace "b12"
     -- known method
     req <- lift request
@@ -184,89 +157,86 @@ b12 r@Resource{..} = do
                        , HTTP.methodPatch
                        ]
     if requestMethod req `elem` knownMethods
-        then b11 r
+        then return ()
         else lift $ halt HTTP.status501
 
-b11 r@Resource{..} = do
+b11 :: Monad m => Bool -> FlowStateT m ()
+b11 long = do
     trace "b11"
-    long <- lift uriTooLong
     if long
         then lift $ halt HTTP.status414
-        else b10 r
+        else return ()
 
-b10 r@Resource{..} = do
+b10 :: Monad m => [HTTP.Method] -> FlowStateT m ()
+b10 allowed = do
     trace "b10"
     req <- lift request
-    allowed <- lift allowedMethods
     if requestMethod req `elem` allowed
-        then b09 r
+        then return ()
         else do
             lift $ addResponseHeader ("Allow",  intercalate "," allowed)
             lift $ halt HTTP.status405
 
-b09 r@Resource{..} = do
+b09 :: Monad m => Bool -> FlowStateT m ()
+b09 malformed = do
     trace "b09"
-    malformed <- lift malformedRequest
     if malformed
         then lift $ halt HTTP.status400
-        else b08 r
+        else return ()
 
-b08 r@Resource{..} = do
+b08 :: Monad m => Bool -> FlowStateT m ()
+b08 authorized = do
     trace "b08"
-    authorized <- lift isAuthorized
     if authorized
-        then b07 r
+        then return ()
         else lift $ halt HTTP.status401
 
-b07 r@Resource{..} = do
+b07 :: Monad m => Bool -> FlowStateT m ()
+b07 forbid = do
     trace "b07"
-    forbid <- lift forbidden
     if forbid
         then lift $ halt HTTP.status403
-        else b06 r
+        else return ()
 
-b06 r@Resource{..} = do
+b06 :: Monad m => Bool -> FlowStateT m ()
+b06 validC = do
     trace "b06"
-    validC <- lift validContentHeaders
     if validC
-        then b05 r
+        then return ()
         else lift $ halt HTTP.status501
 
-b05 r@Resource{..} = do
+b05 :: Monad m => Bool -> FlowStateT m ()
+b05 known = do
     trace "b05"
-    known <- lift knownContentType
     if known
-        then b04 r
+        then return ()
         else lift $ halt HTTP.status415
 
-b04 r@Resource{..} = do
+b04 :: Monad m => Bool-> FlowStateT m ()
+b04 large = do
     trace "b04"
-    large <- lift entityTooLarge
     if large
         then lift $ halt HTTP.status413
-        else b03 r
+        else return ()
 
-b03 r@Resource{..} = do
+b03 :: Monad m => [HTTP.Method] -> FlowStateT m ()
+b03 allowed = do
     trace "b03"
     req <- lift request
-    allowed <- lift allowedMethods
     if requestMethod req == HTTP.methodOptions
         then do
             lift $ addResponseHeader ("Allow",  intercalate "," allowed)
             lift $ halt HTTP.status204
-        else c03 r
+        else return ()
 
 ------------------------------------------------------------------------------
 -- C column
 ------------------------------------------------------------------------------
 
-c04 r@Resource{..} = do
+c04 :: Monad m => AcceptHeader -> [(MediaType, a)] -> FlowStateT m (MediaType, a)
+c04 (AcceptHeader acceptStr) provided = do
     trace "c04"
-    req <- lift request
-    provided <- lift contentTypesProvided
-    let reqHeaders = requestHeaders req
-        result = do
-            acceptStr <- lookup HTTP.hAccept reqHeaders
+    let result = do
             (acceptTyp, resource) <- mapAcceptMedia provided' acceptStr
             Just (acceptTyp, resource)
             where
@@ -277,152 +247,125 @@ c04 r@Resource{..} = do
                 dupContentType (a, b) = (a, (a, b))
 
     case result of
-      Nothing -> lift $ halt HTTP.status406
-      Just res -> do
-        modify (\fs -> fs { _contentType = Just res })
-        d04 r
+        Nothing -> lift $ halt HTTP.status406
+        Just res ->
+            return res
 
-c03 r@Resource{..} = do
+c03 :: Monad m => FlowStateT m (Maybe AcceptHeader)
+c03 = do
     trace "c03"
-    req <- lift request
-    let reqHeaders = requestHeaders req
-    case lookup HTTP.hAccept reqHeaders of
-        (Just _h) ->
-            c04 r
-        Nothing ->
-            d04 r
+    fmap AcceptHeader . lookup HTTP.hAccept . requestHeaders <$> lift request
 
 ------------------------------------------------------------------------------
 -- D column
 ------------------------------------------------------------------------------
 
-d05 r@Resource{..} = do
+d05 :: Monad m => Bool -> FlowStateT m ()
+d05 langAvailable = do
     trace "d05"
-    langAvailable <- lift languageAvailable
     if langAvailable
-        then e05 r
+        then return ()
         else lift $ halt HTTP.status406
 
-d04 r@Resource{..} = do
+d04 :: Monad m => FlowStateT m (Maybe AcceptLanguage)
+d04 = do
     trace "d04"
-    req <- lift request
-    let reqHeaders = requestHeaders req
-    case lookup HTTP.hAcceptLanguage reqHeaders of
-        (Just _h) ->
-            d05 r
-        Nothing ->
-            e05 r
+    fmap AcceptLanguage . lookup HTTP.hAcceptLanguage . requestHeaders <$> lift request
 
 ------------------------------------------------------------------------------
 -- E column
 ------------------------------------------------------------------------------
 
-e06 r@Resource{..} = do
+e06 :: Monad m => AcceptCharset -> FlowStateT m ()
+e06 (AcceptCharset _) = do
     trace "e06"
     -- TODO: charset negotiation
-    f06 r
+    return ()
 
-e05 r@Resource{..} = do
+e05 :: Monad m => FlowStateT m (Maybe AcceptCharset)
+e05 = do
     trace "e05"
-    req <- lift request
-    let reqHeaders = requestHeaders req
-    case lookup hAcceptCharset reqHeaders of
-        (Just _h) ->
-            e06 r
-        Nothing ->
-            f06 r
+    fmap AcceptCharset . lookup hAcceptCharset . requestHeaders <$> lift request
+
 
 ------------------------------------------------------------------------------
 -- F column
 ------------------------------------------------------------------------------
 
-f07 r@Resource{..} = do
+f07 :: Monad m => AcceptEncoding -> FlowStateT m ()
+f07 (AcceptEncoding _) = do
     trace "f07"
     -- TODO: encoding negotiation
-    g07 r
+    return ()
 
-f06 r@Resource{..} = do
+f06 :: Monad m => FlowStateT m (Maybe AcceptEncoding)
+f06 = do
     trace "f06"
     req <- lift request
-    let reqHeaders = requestHeaders req
-    case lookup hAcceptEncoding reqHeaders of
-        (Just _h) ->
-            f07 r
-        Nothing ->
-            g07 r
+    return . fmap AcceptEncoding . lookup hAcceptEncoding . requestHeaders $ req
 
 ------------------------------------------------------------------------------
 -- G column
 ------------------------------------------------------------------------------
 
-g11 (IfMatch ifMatch) r@Resource{..} = do
+g11 :: Monad m => IfMatch -> FlowStateT m ()
+g11 (IfMatch ifMatch) = do
     trace "g11"
     let etags = parseEtagList ifMatch
     if null etags
         then lift $ halt HTTP.status412
-        else h10 r
+        else return ()
 
-g09 ifMatch r@Resource{..} = do
+g09 :: Monad m => IfMatch -> FlowStateT m (Maybe IfMatch)
+g09 ifMatch = do
     trace "g09"
     case ifMatch of
         -- TODO: should we be stripping whitespace here?
         (IfMatch "*") ->
-            h10 r
+            return Nothing
         _ ->
-            g11 ifMatch r
+            return $ Just ifMatch
 
-g08 r@Resource{..} = do
+g08 :: Monad m => FlowStateT m (Maybe IfMatch)
+g08 = do
     trace "g08"
     req <- lift request
     let reqHeaders = requestHeaders req
-    case IfMatch <$> lookup hIfMatch reqHeaders of
-        (Just h) ->
-            g09 h r
-        Nothing ->
-            h10 r
+    return $ IfMatch <$> lookup hIfMatch reqHeaders
 
-g07 r@Resource{..} = do
+g07 :: Monad m => Bool -> FlowStateT m Bool
+g07 exists = do
     trace "g07"
     -- TODO: set Vary headers
-    exists <- lift resourceExists
-    if exists
-        then g08 r
-        else h07 r
+    return exists
 
 ------------------------------------------------------------------------------
 -- H column
 ------------------------------------------------------------------------------
 
-h12 r@Resource{..} = do
+h12 :: Monad m => Maybe UTCTime -> IfUnmodifiedSince -> FlowStateT m ()
+h12 modified (IfUnmodifiedSince headerDate) = do
     trace "h12"
-    modified <- lift lastModified
-    parsedDate <- lift $ requestHeaderDate hIfUnmodifiedSince
     let maybeGreater = do
             lastM <- modified
-            headerDate <- parsedDate
             return (lastM > headerDate)
     if maybeGreater == Just True
         then lift $ halt HTTP.status412
-        else i12 r
+        else return ()
 
-h11 r@Resource{..} = do
+h11 :: Monad m => IfUnmodifiedSinceHeader -> FlowStateT m (Maybe IfUnmodifiedSince)
+h11 (IfUnmodifiedSinceHeader header) = do
     trace "h11"
-    parsedDate <- lift $ requestHeaderDate hIfUnmodifiedSince
-    if isJust parsedDate
-        then h12 r
-        else i12 r
+    return . fmap IfUnmodifiedSince $ parseRfc1123Date header
 
-h10 r@Resource{..} = do
+h10 :: Monad m => FlowStateT m (Maybe IfUnmodifiedSinceHeader)
+h10 = do
     trace "h10"
     req <- lift request
-    let reqHeaders = requestHeaders req
-    case lookup hIfUnmodifiedSince reqHeaders of
-        (Just _h) ->
-            h11 r
-        Nothing ->
-            i12 r
+    return . fmap IfUnmodifiedSinceHeader . lookup hIfUnmodifiedSince $ requestHeaders req
 
-h07 r@Resource {..} = do
+h07 :: Monad m => FlowStateT m ()
+h07 = do
     trace "h07"
     req <- lift request
     let reqHeaders = requestHeaders req
@@ -431,53 +374,51 @@ h07 r@Resource {..} = do
         (Just "*") ->
             lift $ halt HTTP.status412
         _ ->
-            i07 r
+          return ()
 
 ------------------------------------------------------------------------------
 -- I column
 ------------------------------------------------------------------------------
 
-i13 ifNoneMatch r@Resource{..} = do
+i13 :: Monad m => IfNoneMatch -> FlowStateT m (Maybe IfNoneMatch)
+i13 ifNoneMatch = do
     trace "i13"
     case ifNoneMatch of
         -- TODO: should we be stripping whitespace here?
         (IfNoneMatch "*") ->
-            j18 r
+            return Nothing
         _ ->
-            k13 ifNoneMatch r
+            return $ Just ifNoneMatch
 
-i12 r@Resource{..} = do
+i12 :: Monad m => FlowStateT m (Maybe IfNoneMatch)
+i12 = do
     trace "i12"
     req <- lift request
     let reqHeaders = requestHeaders req
-    case IfNoneMatch <$> lookup hIfNoneMatch reqHeaders of
-        (Just h) ->
-            i13 h r
-        Nothing ->
-            l13 r
+    return $ IfNoneMatch <$> lookup hIfNoneMatch reqHeaders
 
-i07 r = do
+i07 :: Monad m => FlowStateT m Bool
+i07 = do
     trace "i07"
     req <- lift request
-    if requestMethod req == HTTP.methodPut
-        then i04 r
-        else k07 r
+    return $ requestMethod req == HTTP.methodPut
 
-i04 r@Resource{..} = do
+i04 :: Monad m => Maybe Location -> FlowStateT m ()
+i04 moved = do
     trace "i04"
-    moved <- lift movedPermanently
     case moved of
-        (Just loc) -> do
+        Just (Location loc) -> do
             lift $ addResponseHeader ("Location", loc)
             lift $ halt HTTP.status301
         Nothing ->
-            p03 r
+            return ()
 
 ------------------------------------------------------------------------------
 -- J column
 ------------------------------------------------------------------------------
 
-j18 _ = do
+j18 :: Monad m => FlowStateT m a
+j18 = do
     trace "j18"
     req <- lift request
     let getOrHead = [ HTTP.methodGet
@@ -491,236 +432,199 @@ j18 _ = do
 -- K column
 ------------------------------------------------------------------------------
 
-k13 (IfNoneMatch ifNoneMatch) r@Resource{..} = do
+k13 :: Monad m => IfNoneMatch -> FlowStateT m Bool
+k13 (IfNoneMatch ifNoneMatch) = do
     trace "k13"
-    let etags = parseEtagList ifNoneMatch
-    if null etags
-        then l13 r
-        else j18 r
+    return . null $ parseEtagList ifNoneMatch
 
-k07 r@Resource{..} = do
+k07 :: Monad m => Bool -> FlowStateT m Bool
+k07 prevExisted = do
     trace "k07"
-    prevExisted <- lift previouslyExisted
-    if prevExisted
-        then k05 r
-        else l07 r
+    return prevExisted
 
-k05 r@Resource{..} = do
+k05 :: Monad m => Maybe Location -> FlowStateT m ()
+k05 moved = do
     trace "k05"
-    moved <- lift movedPermanently
     case moved of
-        (Just loc) -> do
+        Just (Location loc) -> do
             lift $ addResponseHeader ("Location", loc)
             lift $ halt HTTP.status301
         Nothing ->
-            l05 r
+            return ()
 
 ------------------------------------------------------------------------------
 -- L column
 ------------------------------------------------------------------------------
 
-l17 r@Resource{..} = do
+l17 :: Monad m => Maybe UTCTime -> IfModifiedSince -> FlowStateT m ()
+l17 modified (IfModifiedSince ifModifiedSince) = do
     trace "l17"
-    parsedDate <- lift $ requestHeaderDate HTTP.hIfModifiedSince
-    modified <- lift lastModified
     let maybeGreater = do
             lastM <- modified
-            ifModifiedSince <- parsedDate
             return (lastM > ifModifiedSince)
     if maybeGreater == Just True
-        then m16 r
+        then return ()
         else lift $ halt HTTP.status304
 
-l15 r@Resource{..} = do
+l15 :: Monad m => IfModifiedSince -> FlowStateT m Bool
+l15 (IfModifiedSince ifModifiedSince) = do
     trace "l15"
-    parsedDate <- lift $ requestHeaderDate HTTP.hIfModifiedSince
     now <- lift requestTime
-    let maybeGreater = (> now) <$> parsedDate
-    if maybeGreater == Just True
-        then m16 r
-        else l17 r
+    return $ ifModifiedSince > now
 
-l14 r@Resource{..} = do
+l14 :: Monad m => IfModifiedSinceHeader -> FlowStateT m (Maybe IfModifiedSince)
+l14 (IfModifiedSinceHeader dateHeader) = do
     trace "l14"
-    req <- lift request
-    let reqHeaders = requestHeaders req
-        dateHeader = lookup HTTP.hIfModifiedSince reqHeaders
-        validDate = isJust (dateHeader >>= parseRfc1123Date)
-    if validDate
-        then l15 r
-        else m16 r
+    return . fmap IfModifiedSince . parseRfc1123Date $ dateHeader
 
-l13 r@Resource{..} = do
+l13 :: Monad m => FlowStateT m (Maybe IfModifiedSinceHeader)
+l13 = do
     trace "l13"
     req <- lift request
     let reqHeaders = requestHeaders req
-    case lookup HTTP.hIfModifiedSince reqHeaders of
-        (Just _h) ->
-            l14 r
-        Nothing ->
-            m16 r
+    return . fmap IfModifiedSinceHeader $ lookup HTTP.hIfModifiedSince reqHeaders
 
-l07 r = do
+l07 :: Monad m => FlowStateT m ()
+l07 = do
     trace "l07"
     req <- lift request
     if requestMethod req == HTTP.methodPost
-        then m07 r
+        then return ()
         else lift $ halt HTTP.status404
 
-l05 r@Resource{..} = do
+l05 :: Monad m => Maybe Location -> FlowStateT m ()
+l05 moved = do
     trace "l05"
-    moved <- lift movedTemporarily
     case moved of
-        (Just loc) -> do
+        Just (Location loc) -> do
             lift $ addResponseHeader ("Location", loc)
             lift $ halt HTTP.status307
         Nothing ->
-            m05 r
+            return ()
 
 ------------------------------------------------------------------------------
 -- M column
 ------------------------------------------------------------------------------
 
-m20 r@Resource{..} = do
+m20 :: Monad m => Bool -> FlowStateT m ()
+m20 completed = do
     trace "m20"
-    deleteAccepted <- lift deleteResource
-    if deleteAccepted
-        then do
-            completed <- lift deleteCompleted
-            if completed
-                then o20 r
-                else lift $ halt HTTP.status202
-        else lift $ halt HTTP.status500
+    if completed
+        then return ()
+        else lift $ halt HTTP.status202
 
-m16 r = do
+m16 :: Monad m => FlowStateT m Bool
+m16 = do
     trace "m16"
     req <- lift request
-    if requestMethod req == HTTP.methodDelete
-        then m20 r
-        else n16 r
+    return $ requestMethod req == HTTP.methodDelete
 
-m07 r@Resource{..} = do
+m07 :: Monad m => Bool -> FlowStateT m ()
+m07 allowMissing = do
     trace "m07"
-    allowMissing <- lift allowMissingPost
     if allowMissing
-        then n11 r
+        then return ()
         else lift $ halt HTTP.status404
 
-m05 r = do
+m05 :: Monad m => FlowStateT m ()
+m05 = do
     trace "m05"
     req <- lift request
     if requestMethod req == HTTP.methodPost
-        then n05 r
+        then return ()
         else lift $ halt HTTP.status410
 
 ------------------------------------------------------------------------------
 -- N column
 ------------------------------------------------------------------------------
 
-n16 r = do
+n16 :: Monad m => FlowStateT m Bool
+n16 = do
     trace "n16"
     req <- lift request
-    if requestMethod req == HTTP.methodPost
-        then n11 r
-        else o16 r
+    return $ requestMethod req == HTTP.methodPost
 
-n11 r@Resource{..} = trace "n11" >> lift processPost >>= flip processPostAction r
+n11 :: Monad m => Maybe Location -> FlowStateT m ()
+n11 location = do
+    trace "n11"
+    case location of
+        Just (Location loc) -> do
+            lift $ setResponseHeader (HTTP.hLocation, loc)
+            lift $ halt HTTP.status303
+        _ ->
+            return ()
 
-create :: Monad m => [Text] -> Resource m -> FlowStateT m ()
-create ts r = do
-    loc <- lift (appendRequestPath ts)
-    lift (addResponseHeader ("Location", loc))
-    negotiateContentTypesAccepted r
-
-processPostAction :: Monad m => PostResponse m -> Flow  m
-processPostAction (PostCreate ts) r = do
-    create ts r
-    p11 r
-processPostAction (PostCreateRedirect ts) r = do
-    create ts r
-    lift $ halt HTTP.status303
-processPostAction (PostProcess p) r =
-    lift p >> p11 r
-processPostAction (PostProcessRedirect ts) _r = do
-    locBs <- lift ts
-    lift $ addResponseHeader ("Location", locBs)
-    lift $ halt HTTP.status303
-
-n05 r@Resource{..} = do
+n05 :: Monad m => Bool -> FlowStateT m ()
+n05 allow = do
     trace "n05"
-    allow <- lift allowMissingPost
     if allow
-        then n11 r
+        then return ()
         else lift $ halt HTTP.status410
 
 ------------------------------------------------------------------------------
 -- O column
 ------------------------------------------------------------------------------
 
-o20 r = do
+o20 :: Monad m => ResponseBody -> FlowStateT m ()
+o20 body = do
     trace "o20"
-    body <- lift getResponseBody
     -- ResponseBody is a little tough to make an instance of 'Eq',
     -- so we just use a pattern match
     case body of
         Empty   -> lift $ halt HTTP.status204
-        _       -> o18 r
+        _       -> return ()
 
-o18 r@Resource{..} = do
+o18 :: Monad m => Bool -> CacheData -> MediaType -> Webmachine m ResponseBody -> FlowStateT m a
+o18 multiple (CacheData modified' etag') cType body' = do
     trace "o18"
-    multiple <- lift multipleChoices
     if multiple
+        -- TODO I believe this can/should also set the body
         then lift $ halt HTTP.status300
         else do
+            body <- lift body'
             -- TODO: set etag, expiration, etc. headers
             req <- lift request
             let getOrHead = [ HTTP.methodGet
                             , HTTP.methodHead
                             ]
             when (requestMethod req `elem` getOrHead) $ do
-                m <- _contentType <$> get
-                (cType, body) <- case m of
-                    Nothing -> do
-                        provided <- lift contentTypesProvided
-                        return (head provided)
-                    Just (cType, body) ->
-                        return (cType, body)
-                b <- lift body
-                lift $ putResponseBody b
+                lift $ putResponseBody body
                 lift $ addResponseHeader ("Content-Type", renderHeader cType)
-            writeCacheTags r
+            lift . F.forM_ modified' $ addResponseHeader . (,) "Last-Modified" . utcTimeToRfc1123
+            lift . F.forM_ etag' $ addResponseHeader . (,) "ETag" . etagToByteString
             lift $ halt HTTP.status200
 
-o16 r = do
+o16 :: Monad m => FlowStateT m Bool
+o16 = do
     trace "o16"
     req <- lift request
-    if requestMethod req == HTTP.methodPut
-        then o14 r
-        else o18 r
+    return $ requestMethod req == HTTP.methodPut
 
-o14 r@Resource{..} = do
+o14 :: Monad m => Bool -> FlowStateT m ()
+o14 conflict = do
     trace "o14"
-    conflict <- lift isConflict
     if conflict
         then lift $ halt HTTP.status409
-        else negotiateContentTypesAccepted r >> p11 r
+        else return ()
 
 ------------------------------------------------------------------------------
 -- P column
 ------------------------------------------------------------------------------
 
-p11 r = do
+
+p11 :: Monad m => Maybe Location -> FlowStateT m ()
+p11 location = do
     trace "p11"
-    headers <- lift getResponseHeaders
-    case lookup HTTP.hLocation headers of
-        (Just _) ->
+    case location of
+        Just (Location loc) -> do
+            lift $ setResponseHeader (HTTP.hLocation, loc)
             lift $ halt HTTP.status201
         _ ->
-            o20 r
+            return ()
 
-p03 r@Resource{..} = do
+p03 :: Monad m => Bool -> FlowStateT m ()
+p03 conflict = do
     trace "p03"
-    conflict <- lift isConflict
     if conflict
         then lift $ halt HTTP.status409
-        else negotiateContentTypesAccepted r >> p11 r
+        else return ()

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -5,7 +5,6 @@
 
 module Airship.Internal.Helpers
     ( parseFormData
-    , contentTypeMatches
     , redirectTemporarily
     , redirectPermanently
     , appendRequestPath
@@ -21,7 +20,6 @@ import           Control.Applicative
 #endif
 import           Data.ByteString           (ByteString)
 import qualified Data.ByteString.Lazy      as LazyBS
-import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 710
 import           Data.Monoid
 #endif
@@ -29,7 +27,6 @@ import qualified Data.HashMap.Strict       as HM
 import           Data.Text                 (Text, intercalate)
 import           Data.Text.Encoding
 import           Lens.Micro                ((^.))
-import           Network.HTTP.Media
 import qualified Network.HTTP.Types        as HTTP
 import qualified Network.Wai               as Wai
 
@@ -47,17 +44,6 @@ import           Airship.Types
 -- files and their information.
 parseFormData :: Request -> IO ([Param], [File LazyBS.ByteString])
 parseFormData r = parseRequestBody lbsBackEnd r
-
--- | Returns @True@ if the request's @Content-Type@ header is one of the
--- provided media types. If the @Content-Type@ header is not present,
--- this function will return True.
-contentTypeMatches :: Monad m => [MediaType] -> Webmachine m Bool
-contentTypeMatches validTypes = do
-    headers <- requestHeaders <$> request
-    let cType = lookup HTTP.hContentType headers
-    return $ case cType of
-        Nothing -> True
-        Just t  -> isJust $ matchAccept validTypes t
 
 -- | Issue an HTTP 302 (Found) response, with `location' as the destination.
 redirectTemporarily :: Monad m => ByteString -> Webmachine m a

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -7,7 +7,6 @@
 module Airship.Resource
     ( Resource(..)
     , PostResponse(..)
-    , serverError
     , defaultResource
     ) where
 
@@ -105,10 +104,6 @@ data Resource m =
                -- | Returns @501 Not Implemented@ if false. Default: true.
              , validContentHeaders      :: Webmachine m Bool
              }
-
--- | A helper function that terminates execution with @500 Internal Server Error@.
-serverError :: Monad m => Webmachine m a
-serverError = finishWith (Response status500 [] Empty)
 
 -- | The default Airship resource, with "sensible" values filled in for each entry.
 -- You construct new resources by extending the default resource with your own handlers.

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -24,7 +24,6 @@ import Network.HTTP.Media (MediaType)
 -- Credit for this idea goes to Richard Wallace (purefn) on Webcrank.
 data PostResponse m
     = PostCreate [Text] -- ^ Treat this request as a PUT.
-    | PostCreateRedirect [Text] -- ^ Treat this request as a PUT, then redirect.
     | PostProcess (Webmachine m ()) -- ^ Process as a POST, but don't redirect.
     | PostProcessRedirect (Webmachine m ByteString) -- ^ Process and redirect.
 
@@ -65,9 +64,6 @@ data Resource m =
              , isAuthorized             :: Webmachine m Bool
                -- | When processing @PUT@ requests, a @True@ value returned here will halt processing with a @409 Conflict@.
              , isConflict               :: Webmachine m Bool
-               -- | Returns @415 Unsupported Media Type@ if false. We recommend you use the 'contentTypeMatches' helper function, which accepts a list of
-               -- 'MediaType' values, so as to simplify proper MIME type handling. Default: true.
-             , knownContentType         :: Webmachine m Bool
                -- | In the presence of an @If-Modified-Since@ header, returning a @Just@ value from 'lastModifed' allows
                -- the server to halt with @304 Not Modified@ if appropriate.
              , lastModified             :: Webmachine m (Maybe UTCTime)
@@ -120,7 +116,6 @@ defaultResource = Resource { allowMissingPost       = return False
                            , implemented            = return True
                            , isAuthorized           = return True
                            , isConflict             = return False
-                           , knownContentType       = return True
                            , lastModified           = return Nothing
                            , languageAvailable      = return True
                            , malformedRequest       = return False

--- a/src/Airship/Resource/Decision.hs
+++ b/src/Airship/Resource/Decision.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Airship.Resource.Decision
+  ( flow
+  ) where
+
+import           Airship.Internal.Decision

--- a/src/Airship/Resource/Decision.hs
+++ b/src/Airship/Resource/Decision.hs
@@ -6,4 +6,157 @@ module Airship.Resource.Decision
   ( flow
   ) where
 
+import           Airship.Headers (addResponseHeader)
 import           Airship.Internal.Decision
+import           Airship.Resource
+import           Airship.Types
+
+#if __GLASGOW_HASKELL__ < 710
+import           Control.Applicative ((<$>), (<*>))
+#endif
+import           Control.Monad (unless)
+import           Control.Monad.Trans (lift)
+import           Control.Monad.Trans.State.Strict (evalStateT)
+
+import           Data.ByteString (ByteString)
+import           Data.Foldable (traverse_)
+import           Data.Traversable (traverse)
+
+import           Network.HTTP.Media (MediaType, mapContentMedia)
+import qualified Network.HTTP.Types as HTTP
+
+
+flow :: Monad m => Resource m -> Webmachine m Response
+flow r@Resource{..} = flip evalStateT () $ do
+    validate r
+    ctp <- accept r
+    cache <- lift resourceExists >>= g07 >>= \case
+        False -> do
+            create r
+            lift $ resourceCacheData r
+        True -> do
+            cache <- lift $ resourceCacheData r
+            preconditions cache
+            process r
+            return cache
+    ok r ctp cache
+
+validate :: Monad m => Resource m -> FlowStateT m ()
+validate Resource{..} = do
+    lift serviceAvailable >>= b13
+    b12
+    lift uriTooLong >>= b11
+    lift allowedMethods >>= b10
+    lift malformedRequest >>= b09
+    lift isAuthorized >>= b08
+    lift forbidden >>= b07
+    lift validContentHeaders >>= b06
+    lift knownContentType >>= b05
+    lift entityTooLarge >>= b04
+    lift allowedMethods >>= b03
+
+accept :: Monad m => Resource m -> FlowStateT m (Maybe (MediaType, Webmachine m ResponseBody))
+accept Resource{..} = do
+    ctp <- c03 >>= traverse (\a -> lift contentTypesProvided >>= c04 a)
+    d04 >>= traverse_ (\_ -> lift languageAvailable >>= d05)
+    e05 >>= traverse_ e06
+    f06 >>= traverse_ f07
+    return ctp
+
+create :: Monad m => Resource m -> FlowStateT m ()
+create r@Resource{..} = do
+    h07
+    i07 >>= \case
+        True -> do
+            lift movedPermanently >>= i04 . fmap Location
+            lift isConflict >>= p03
+            negotiateContentTypesAccepted r
+            p11' r
+        False ->
+            lift previouslyExisted >>= k07 >>= \case
+                True -> do
+                    lift movedPermanently >>= k05 . fmap Location
+                    lift movedTemporarily >>= l05 . fmap Location
+                    m05
+                    lift allowMissingPost >>= n05
+                    n11' r
+                False -> do
+                    l07
+                    lift allowMissingPost >>= m07
+                    n11' r
+
+process :: Monad m => Resource m -> FlowStateT m ()
+process r@Resource{..} =
+    m16 >>= \case
+        True -> do
+            lift deleteResource >>= flip unless (lift $ halt HTTP.status500)
+            lift deleteCompleted >>= m20
+            lift getResponseBody >>= o20
+        False ->
+            n16 >>= \case
+               True ->
+                   n11' r
+               False ->
+                   o16 >>= \case
+                       False ->
+                           return ()
+                       True -> do
+                           lift isConflict >>= o14
+                           negotiateContentTypesAccepted r
+                           p11' r
+
+ok :: Monad m => Resource m -> Maybe (MediaType, Webmachine m ResponseBody) -> CacheData -> FlowStateT m Response
+ok Resource{..} ctp cache = do
+    mc <- lift multipleChoices
+    (a, p) <- maybe (head <$> lift contentTypesProvided) return ctp
+    o18 mc cache a p
+
+n11' :: Monad m => Resource m -> FlowStateT m ()
+n11' r@Resource{..} = do
+    lift processPost >>= processPostAction r
+    lift responseLocation >>= p11 . fmap Location
+    lift getResponseBody >>= o20
+
+p11' :: Monad m => Resource m -> FlowStateT m ()
+p11' Resource{..} = do
+    lift responseLocation >>= p11 . fmap Location
+    lift getResponseBody >>= o20
+
+processPostAction :: Monad m => Resource m -> PostResponse m -> FlowStateT m ()
+processPostAction r = \case
+    PostCreate ts -> do
+        n11 Nothing
+        loc <- lift (appendRequestPath ts)
+        lift (addResponseHeader ("Location", loc))
+    PostCreateRedirect ts -> do
+        n11 Nothing
+        loc <- lift (appendRequestPath ts)
+        lift (addResponseHeader ("Location", loc))
+        negotiateContentTypesAccepted r
+        lift $ halt HTTP.status303
+    PostProcess p -> do
+        n11 Nothing
+        lift p
+    PostProcessRedirect ts -> do
+        locBs <- lift ts
+        n11 . Just $ Location locBs
+
+resourceCacheData :: Monad m => Resource m -> Webmachine m CacheData
+resourceCacheData Resource{..} =
+    CacheData <$> lastModified <*> generateETag
+
+responseLocation :: Monad m => Webmachine m (Maybe ByteString)
+responseLocation =
+    lookup HTTP.hLocation <$> getResponseHeaders
+
+negotiateContentTypesAccepted :: Monad m => Resource m -> FlowStateT m ()
+negotiateContentTypesAccepted Resource{..} = do
+    req <- lift request
+    accepted <- lift contentTypesAccepted
+    let reqHeaders = requestHeaders req
+        result = do
+            cType <- lookup HTTP.hContentType reqHeaders
+            mapContentMedia accepted cType
+    case result of
+        (Just process') -> lift process'
+        Nothing -> lift $ halt HTTP.status415

--- a/src/Airship/Resource/Route.hs
+++ b/src/Airship/Resource/Route.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Airship.Resource.Route
+  ( RoutingSpec
+  , runRouter
+  ) where
+
+import           Airship.Resource
+import           Airship.Route
+
+#if __GLASGOW_HASKELL__ < 710
+import           Control.Applicative
+#endif
+import           Control.Monad.Identity
+import           Control.Monad.Writer (Writer, WriterT (..), execWriter)
+import           Control.Monad.Writer.Class (MonadWriter)
+
+
+runRouter :: RoutingSpec m a -> [(Route, Resource m)]
+runRouter routes = execWriter (getRouter routes)
+
+-- | Represents a fully-specified set of routes that map paths (represented as 'Route's) to 'Resource's. 'RoutingSpec's are declared with do-notation, to wit:
+--
+-- @
+--    myRoutes :: RoutingSpec IO ()
+--    myRoutes = do
+--      root                                 #> myRootResource
+--      "blog" '</>' var "date" '</>' var "post" #> blogPostResource
+--      "about"                              #> aboutResource
+--      "anything" '</>' star                  #> wildcardResource
+-- @
+--
+newtype RoutingSpec m a = RoutingSpec { getRouter :: Writer [(Route, Resource m)] a }
+    deriving (Functor, Applicative, Monad, MonadWriter [(Route, Resource m)])

--- a/src/Airship/Resource/Wai.hs
+++ b/src/Airship/Resource/Wai.hs
@@ -1,0 +1,34 @@
+module Airship.Resource.Wai
+  ( resourceToWai
+  , resourceToWaiT
+  ) where
+
+import           Airship.Config
+import           Airship.Internal.Route
+import           Airship.Internal.Helpers
+import           Airship.Resource
+import           Airship.Resource.Decision
+import           Airship.Resource.Route
+import           Airship.Types
+
+import           Data.Time                 (getCurrentTime)
+
+import qualified Network.Wai               as Wai
+
+
+-- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
+resourceToWai :: AirshipConfig -> RoutingSpec IO () -> Resource IO -> Wai.Application
+resourceToWai cfg routes resource404 =
+  resourceToWaiT cfg (const id) routes resource404
+
+-- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
+resourceToWaiT :: Monad m => AirshipConfig -> (Request -> m Wai.Response -> IO Wai.Response) -> RoutingSpec m () -> Resource m -> Wai.Application
+resourceToWaiT cfg run routes resource404 req respond = do
+    let routeMapping = runRouter routes
+        pInfo = Wai.pathInfo req
+        (resource, (params', matched)) = route routeMapping pInfo resource404
+    nowTime <- getCurrentTime
+    quip <- getQuip
+    (=<<) respond . run req $ do
+      (response, trace) <- eitherResponse nowTime params' matched req (flow resource)
+      return $ toWaiResponse response cfg (traceHeader trace) quip

--- a/src/Airship/Resource2/Data.hs
+++ b/src/Airship/Resource2/Data.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Airship.Resource2.Data
+  ( Available (..)
+  , MOtherAction (..)
+  , MPostAction (..)
+  , MPutAction (..)
+  , Moved (..)
+  , MultipleRepresentations (..)
+  , OctetStream (..)
+  , Resource
+  , ResourceDenied (..)
+  , ResourceDesc (..)
+  , ResponseEntity (..)
+  , ResourceExists (..)
+  , ResourceMethod (..)
+  , ResourceNotFoundMethod (..)
+  , RDeleteAction (..)
+  , RPostAction (..)
+  , RPutAction (..)
+  , ok
+  , resourceDesc
+  ) where
+
+import           Airship.Internal.Decision
+import           Airship.Types
+
+import           Data.List.NonEmpty (NonEmpty (..))
+
+import           Network.HTTP.Media (MediaType)
+import           Network.HTTP.Types (Method)
+import qualified Network.HTTP.Types as HTTP
+
+
+data ResourceDesc a b =
+  ResourceDesc {
+    serviceAvailable :: Available
+  , allowedMethods :: [Method]
+  , contentTypesAccepted :: NonEmpty (MediaType, a)
+  , contentTypesProvided :: NonEmpty (MediaType, b)
+  , languageAvailable :: AcceptLanguage -> Bool
+  }
+
+data ResourceDenied =
+    Forbidden
+  | Unauthorized
+  | MalformedRequest
+  | UnsupportedContentType
+  | UriTooLong
+  | EntityTooLarge
+  deriving (Eq, Show)
+
+data Available =
+    Available
+  | Unavailable
+  deriving (Eq, Show)
+
+data MultipleRepresentations =
+    MultipleRepresentations
+  | OK
+  deriving (Eq, Show)
+
+data Moved =
+    MovedPermanently Location
+  | MovedTemporarily Location
+  deriving (Eq, Show)
+
+data ResponseEntity =
+    ResponseEntity MultipleRepresentations ResponseBody
+
+
+type Resource m = FlowStateT m ()
+
+
+data ResourceExists m =
+    ResourceExists CacheData (ResourceMethod m -> m ())
+  | ResourceNotFound (ResourceNotFoundMethod m -> m ())
+
+data ResourceMethod m =
+    RPut (RPutAction -> m ())
+  | RPost (RPostAction -> m ())
+  | RDelete (RDeleteAction -> m ())
+  | ROther (ResponseEntity -> m ())
+
+data ResourceNotFoundMethod m =
+    MPut (MPutAction -> m ())
+  | MPost (MPostAction -> m ())
+  | MOther (MOtherAction -> m ())
+
+data RPutAction =
+    RPutConflict
+  | RPutCreated Location
+  | RPutOk ResponseEntity
+
+data RPostAction =
+    RPostSeeOther Location
+  | RPostCreated Location
+  | RPostOk ResponseEntity
+
+data RDeleteAction =
+    RDeleteAccepted
+  | RDeleteOk ResponseEntity
+
+data MPutAction =
+    MPutMoved Location
+  | MPutConflict
+  | MPutCreated Location
+  | MPutOk CacheData ResponseEntity
+
+data MPostAction =
+    MPostMoved Moved
+  | MPostGone
+  | MPostNotFound
+  | MPostSeeOther Location
+  | MPostRedirect Location
+  | MPostOk CacheData ResponseEntity
+
+data MOtherAction =
+    MOtherMoved Moved
+  | MOtherGone
+  | MOtherNotFound
+
+
+data OctetStream = OctetStream deriving (Eq, Show)
+
+
+resourceDesc :: ResourceDesc OctetStream OctetStream
+resourceDesc =
+    ResourceDesc
+        Available
+        [HTTP.methodGet, HTTP.methodHead]
+        (("application/octet-stream", OctetStream) :| [])
+        (("application/octet-stream", OctetStream) :| [])
+        (const True)
+
+ok :: ResponseBody -> ResponseEntity
+ok =
+    ResponseEntity OK

--- a/src/Airship/Resource2/Decision.hs
+++ b/src/Airship/Resource2/Decision.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Airship.Resource2.Decision
+  ( flow
+  , resource
+  ) where
+
+import           Airship.Internal.Decision
+import           Airship.Resource2.Data
+import           Airship.Types
+
+import           Data.Foldable (traverse_)
+import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (fromMaybe)
+import           Data.Traversable (traverse)
+
+import           Control.Monad.Trans.Class (lift)
+import           Control.Monad.Trans.State.Strict
+
+import           Network.HTTP.Media (MediaType)
+import qualified Network.HTTP.Types as HTTP
+
+
+flow :: Monad m => FlowStateT m a -> Webmachine m Response
+flow f =
+    -- By this point we will always reach a decision point
+    flip evalStateT () f >> halt HTTP.status500
+
+resource ::
+     Monad m
+  => ResourceDesc a b
+  -> Webmachine m (Either ResourceDenied (a -> b -> Webmachine m (ResourceExists (FlowStateT m))))
+  -> Resource m
+resource rd m = do
+    (a, (accept, b), re) <- newResource rd m
+    lift (re a b) >>= \case
+        ResourceExists c run ->
+            resourceExists accept c >>= run
+        ResourceNotFound run ->
+            resourceNotFound accept >>= run
+
+resourceExists :: Monad m => MediaType -> CacheData -> FlowStateT m (ResourceMethod (FlowStateT m))
+resourceExists accept cache = do
+    _ <- g07 True
+    preconditions cache
+    let ok'' f = return . f . ((ok' accept cache =<<) .)
+    m16 >>= \case
+        True -> ok'' RDelete deleteResource
+        False -> n16 >>= \case
+            True -> ok'' RPost postResource
+            False -> o16 >>= \case
+                True -> ok'' RPut putResource
+                False -> ok'' ROther return
+
+resourceNotFound :: Monad m => MediaType -> FlowStateT m (ResourceNotFoundMethod (FlowStateT m))
+resourceNotFound accept = do
+    _ <- g07 False
+    h07
+    i07 >>= \case
+        True ->
+          return . MPut $ putNewResource accept
+        False ->
+            -- Peeking ahead to l7/m5 so we can use better types
+            fmap ((==) HTTP.methodPost . requestMethod) (lift request) >>= \case
+                True -> return . MPost $ postNewResource accept
+                False -> return . MOther $ otherNewResource
+
+deleteResource :: Monad m => RDeleteAction -> FlowStateT m ResponseEntity
+deleteResource = \case
+    RDeleteAccepted -> do
+        m20 False
+        lift serverError
+    RDeleteOk re -> do
+        m20 True
+        return re
+
+putResource :: Monad m => RPutAction -> FlowStateT m ResponseEntity
+putResource = \case
+    RPutConflict -> do
+        o14 True
+        lift serverError
+    RPutCreated l -> do
+        o14 False
+        p11 $ Just l
+        lift serverError
+    RPutOk re -> do
+        o14 False
+        p11 Nothing
+        return re
+
+postResource :: Monad m => RPostAction -> FlowStateT m ResponseEntity
+postResource = \case
+    RPostSeeOther l -> do
+        n11 $ Just l
+        lift serverError
+    RPostCreated l -> do
+        n11 Nothing
+        p11 $ Just l
+        lift serverError
+    RPostOk re -> do
+        n11 Nothing
+        p11 Nothing
+        return re
+
+postNewResource :: Monad m => MediaType -> MPostAction -> FlowStateT m ()
+postNewResource accept = \case
+    MPostMoved moved -> do
+        _ <- k07 True
+        movedResource moved
+    MPostGone -> do
+        _ <- k07 True
+        l07
+        k05 Nothing
+        l05 Nothing
+        m05
+        n05 False
+    MPostNotFound -> do
+        _ <- k07 False
+        l07
+        m07 False
+    MPostSeeOther loc -> do
+        _ <- k07 False
+        l07
+        m07 True
+        n11 $ Just loc
+    MPostRedirect loc -> do
+        _ <- k07 False
+        l07
+        m07 True
+        n11 Nothing
+        p11 $ Just loc
+    MPostOk cache b -> do
+        _ <- k07 False
+        l07
+        m07 True
+        n11 Nothing
+        p11 Nothing
+        ok' accept cache b
+
+otherNewResource :: Monad m => MOtherAction -> FlowStateT m ()
+otherNewResource = \case
+    MOtherMoved moved -> do
+        _ <- k07 True
+        movedResource moved
+    MOtherGone -> do
+        _ <- k07 True
+        k05 Nothing
+        l05 Nothing
+        m05
+        n05 False
+        l07
+    MOtherNotFound -> do
+        _ <- k07 False
+        l07
+
+movedResource :: Monad m => Moved -> FlowStateT m ()
+movedResource = \case
+    MovedPermanently b ->
+        k05 $ Just b
+    MovedTemporarily b -> do
+        k05 Nothing
+        l05 $ Just b
+
+putNewResource :: Monad m => MediaType -> MPutAction -> FlowStateT m ()
+putNewResource accept = \case
+    MPutMoved l ->
+        i04 $ Just l
+    MPutConflict -> do
+        i04 Nothing
+        p03 True
+    MPutCreated l -> do
+        i04 Nothing
+        p03 False
+        p11 $ Just l
+    MPutOk cache re -> do
+        i04 Nothing
+        p03 False
+        p11 Nothing
+        ok' accept cache re
+
+ok' :: Monad m => MediaType -> CacheData -> ResponseEntity -> FlowStateT m ()
+ok' mt cache (ResponseEntity mr b) = do
+    o20 b
+    lift $ putResponseBody b
+    o18 (mr == MultipleRepresentations) cache mt (return b)
+
+newResource :: Monad m => ResourceDesc a b -> Webmachine m (Either ResourceDenied c) -> FlowStateT m (a, (MediaType, b), c)
+newResource (ResourceDesc available methods contentTypes accept lang) rd = do
+    b13 $ available == Available
+    b12
+    b10 methods
+    (contentType, c) <- lift rd >>= \case
+        Left rd' -> do
+            b11 $ rd' == UriTooLong
+            b09 $ rd' == MalformedRequest
+            b08 $ rd' == Unauthorized
+            b07 $ rd' == Forbidden
+            b06 $ rd' == UnsupportedContentType
+            trace "b05"
+            b04 $ rd' == EntityTooLarge
+            -- This is because we're not patching matching so that the trace is correct
+            lift $ halt HTTP.status500
+        Right c -> do
+           a <- fmap (fromMaybe (snd $ NE.head contentTypes)) . b05 $ NE.toList contentTypes
+           return (a, c)
+    b03 methods
+    b <- fmap (fromMaybe (NE.head accept)) $ c03 >>= traverse (\a -> c04 a (NE.toList accept))
+    d04 >>= traverse_ (d05 . lang)
+    e05 >>= traverse_ e06
+    f06 >>= traverse_ f07
+    return (contentType, b, c)

--- a/src/Airship/Resource2/Route.hs
+++ b/src/Airship/Resource2/Route.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Airship.Resource2.Route
+  ( RoutingSpec
+  , runRouter
+  ) where
+
+#if __GLASGOW_HASKELL__ < 710
+import           Control.Applicative
+#endif
+import           Control.Monad.Identity
+import           Control.Monad.Writer (Writer, WriterT (..), execWriter)
+import           Control.Monad.Writer.Class (MonadWriter)
+
+import           Airship.Resource2.Data
+import           Airship.Route
+
+
+runRouter :: RoutingSpec m a -> [(Route, Resource m)]
+runRouter routes = execWriter (getRouter routes)
+
+-- | Represents a fully-specified set of routes that map paths (represented as 'Route's) to 'Resource's. 'RoutingSpec's are declared with do-notation, to wit:
+--
+-- @
+--    myRoutes :: RoutingSpec IO ()
+--    myRoutes = do
+--      root                                 #> myRootResource
+--      "blog" '</>' var "date" '</>' var "post" #> blogPostResource
+--      "about"                              #> aboutResource
+--      "anything" '</>' star                  #> wildcardResource
+-- @
+--
+newtype RoutingSpec m a = RoutingSpec { getRouter :: Writer [(Route, Resource m)] a }
+     deriving (Functor, Applicative, Monad, MonadWriter [(Route, Resource m)])

--- a/src/Airship/Resource2/Wai.hs
+++ b/src/Airship/Resource2/Wai.hs
@@ -1,0 +1,28 @@
+module Airship.Resource2.Wai
+  ( resourceToWaiT
+  ) where
+
+import           Airship.Config
+import           Airship.Internal.Helpers
+import           Airship.Internal.Route
+import           Airship.Resource2.Data
+import           Airship.Resource2.Decision
+import           Airship.Resource2.Route
+import           Airship.Types
+
+import           Data.Time (getCurrentTime)
+
+import qualified Network.Wai as Wai
+
+
+-- | Given a 'RoutingSpec', a 404 resource, and a user state @s@, construct a WAI 'Application'.
+resourceToWaiT :: Monad m => AirshipConfig -> (Request -> m Wai.Response -> IO Wai.Response) -> RoutingSpec m () -> Resource m -> Wai.Application
+resourceToWaiT cfg run routes resource404 req respond = do
+    let routeMapping = runRouter routes
+        pInfo = Wai.pathInfo req
+        (resource', (params', matched)) = route routeMapping pInfo resource404
+    nowTime <- getCurrentTime
+    quip <- getQuip
+    (=<<) respond . run req $ do
+      (response, trace') <- eitherResponse nowTime params' matched req (flow resource')
+      return $ toWaiResponse response cfg (traceHeader trace') quip

--- a/src/Airship/Route.hs
+++ b/src/Airship/Route.hs
@@ -1,6 +1,5 @@
 module Airship.Route
     ( Route
-    , RoutingSpec
     , root
     , var
     , star

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -11,6 +11,8 @@
 
 module Airship.Types
     ( ETag(..)
+    , CacheData(..)
+    , Location(..)
     , Webmachine
     , Request(..)
     , Response(..)
@@ -19,6 +21,7 @@ module Airship.Types
     , defaultRequest
     , entireRequestBody
     , etagToByteString
+    , noCacheData
     , eitherResponse
     , escapedResponse
     , runWebmachine
@@ -90,6 +93,21 @@ instance Show ETag where show = unpack . etagToByteString
 etagToByteString :: ETag -> ByteString
 etagToByteString (Strong bs) = "\"" <> bs <> "\""
 etagToByteString (Weak bs) = "W/\"" <> bs <> "\""
+
+data CacheData =
+  CacheData {
+      cacheModified :: Maybe UTCTime
+    , cacheETag :: Maybe ETag
+    } deriving (Eq, Show)
+
+noCacheData :: CacheData
+noCacheData =
+  CacheData Nothing Nothing
+
+newtype Location =
+  Location {
+      unLocation :: ByteString
+    } deriving (Eq, Show)
 
 -- | Basically Wai's unexported 'Response' type.
 data ResponseBody

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -32,6 +32,7 @@ module Airship.Types
     , putResponseBS
     , halt
     , finishWith
+    , serverError
     , (#>)
     ) where
 
@@ -61,6 +62,7 @@ import Data.Time.Clock (UTCTime)
 
 import Network.HTTP.Types ( ResponseHeaders
                           , Status
+                          , status500
                           )
 
 import qualified Network.Wai as Wai
@@ -186,6 +188,10 @@ halt status = finishWith =<< Response <$> return status <*> getResponseHeaders <
 -- | Immediately halts processing and writes the provided 'Response' back to the client.
 finishWith :: Monad m => Response -> Webmachine m a
 finishWith = Webmachine . left
+
+-- | A helper function that terminates execution with @500 Internal Server Error@.
+serverError :: Monad m => Webmachine m a
+serverError = finishWith (Response status500 [] Empty)
 
 -- | The @#>@ operator provides syntactic sugar for the construction of association lists.
 -- For example, the following assoc list:

--- a/src/Airship2.hs
+++ b/src/Airship2.hs
@@ -1,0 +1,13 @@
+module Airship2 (
+    module X
+  ) where
+
+import           Airship.Config as X
+import           Airship.Headers as X
+import           Airship.Helpers as X
+import           Airship.Resource2.Data as X
+import           Airship.Resource2.Decision as X
+import           Airship.Resource2.Route as X
+import           Airship.Resource2.Wai as X
+import           Airship.Route as X
+import           Airship.Types as X


### PR DESCRIPTION
/cc @reiddraper Part 2. This depends on https://github.com/helium/airship/pull/81. Only the last commit is new - basically this introduces all the files under `Resource2/`. I would recommend looking at the `Basic2.hs` example to get a feel for how it's used.

This is definitely not what I originally had in mind when I described this the other day. As always, definitely open to ideas/suggestion. I've introduced a separate `Airship2` module while this is still an experiment and shouldn't break backwards compatibility in any way.

**Solves**
1. No longer having to rely on `StateT` to pass state around values from functions. Or as we're currently doing not overriding certain fields and just halting manually (eg We never use `resourceExists` because it's easier just to halt on `404`).
2. Data types force correct implementation of the various boolean states so it's hard(er) to get it wrong, and the entire flow is more documented in the types.

**Problems**
1. Diverges from the well-understood `webmachine` pattern matching data type.
2. Specifying the methods in `ResourceDesc` is unrelated to the `ResourceExists` callbacks, which means that you have to ignore parts of the pattern matching depending on what you really care about. I've run out of time to tackle this today, but if/when people start using this in anger I'm sure a few ideas might surface. EDIT: This is obviously no worse than the current situation of course.
