### PR TITLE
Update contentTypeMatches to use matchContent

### DIFF
--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -59,7 +59,7 @@ contentTypeMatches validTypes = do
     let cType = lookup HTTP.hContentType headers
     return $ case cType of
         Nothing -> True
-        Just t  -> isJust $ matchAccept validTypes t
+        Just t  -> isJust $ matchContent validTypes t
 
 -- | Issue an HTTP 302 (Found) response, with `location' as the destination.
 redirectTemporarily :: Monad m => ByteString -> Webmachine m a


### PR DESCRIPTION
Update the contentTypeMatches helper function to call the matchContent
function from the http-media package instead of the matchAccept
function. Based on the function documentation given for the http-media
package, the matchContent function is more appropriate for use in the B5
decision and the matchAccept function would be more appropriate for the
C4 decision. This change makes it possible to use the contentTypeMatches
helper for things like multipart/form-data requests where the
Content-Type header must includes a generated boundary value that could
not be successfully matched when using matchAccept.
