### PR TITLE
Implement custom 404 responses

### DIFF
--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -559,12 +559,17 @@ l13 r@Resource{..} = do
         Nothing ->
             m16 r
 
-l07 r = do
+l07 r@Resource{..} = do
     trace "l07"
     req <- lift request
-    if requestMethod req == HTTP.methodPost
-        then m07 r
-        else lift $ halt HTTP.status404
+    if requestMethod req == HTTP.methodPost then m07 r
+    else do
+        m <- _contentType <$> get
+        when (isJust m) $ do
+            let (Just (ct, body)) = m
+            lift body >>= lift . putResponseBody
+            lift $ addResponseHeader ("Content-Type", renderHeader ct)
+        lift $ halt HTTP.status404
 
 l05 r@Resource{..} = do
     trace "l05"


### PR DESCRIPTION
Airship provides a means to specify a resource used for requests for
undefined routes. This allows for specifying a custom response body to
accompany 404 status codes. Airship does not actually do anything with
these at the present time. This change updates the handling of the L7
node in the decision tree to use the contentTypesProvided by the 404
resource to return a custom response body as intended by the user.

This problem can be observed using the [Basic](https://github.com/helium/airship/blob/master/example/Basic.hs) example. [Here](https://github.com/helium/airship/blob/master/example/Basic.hs#L122) the 
example indicates the desired response body for a 404 request resulting 
from a request to an undefined route, but that response is never returned.

Here is some output from curl hitting the Basic example to illustrate:

```
15:33:33:airship(master) $ curl -v http://localhost:3000/a/b/c
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /a/b/c HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Transfer-Encoding: chunked
< Date: Wed, 10 Feb 2016 22:33:49 GMT
< Server: Warp/3.0.13.1
< Airship-Trace: b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,h07,i07,k07,l07
< Airship-Quip: javascript doesn't have integers
< 
* Connection #0 to host localhost left intact
```

Here is the same request using the changes from this PR:

```
15:33:49:airship(master) $ curl -v http://localhost:3000/a/b/c
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /a/b/c HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Transfer-Encoding: chunked
< Date: Wed, 10 Feb 2016 22:36:07 GMT
< Server: Warp/3.0.13.1
< Airship-Trace: b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,h07,i07,k07,l07
< Airship-Quip: shut it down
< Content-Type: text/html
< 
* Connection #0 to host localhost left intact
&lt;html&gt;&lt;head&gt;&lt;/head&gt;&lt;body&gt;&lt;h1&gt;404 Not Found&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;
```
