### PR TITLE
Custom error response handling

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -42,7 +42,9 @@ library
                       , bytestring
                       , bytestring-trie == 0.2.4.*
                       , case-insensitive
+                      , containers
                       , cryptohash == 0.11.*
+                      , cryptohash == 0.11.6.*
                       , directory
                       , either >= 4.3 && < 4.6
                       , filepath >= 1.3 && < 1.5

--- a/example/Basic.hs
+++ b/example/Basic.hs
@@ -21,6 +21,7 @@ import qualified Data.ByteString.Lazy               as LB
 import           Data.ByteString.Lazy.Char8         (unpack)
 import           Data.HashMap.Strict                (HashMap)
 import qualified Data.HashMap.Strict                as HM
+import qualified Data.Map.Strict                    as M
 import           Data.Maybe                         (fromMaybe)
 import           Data.Monoid                        ((<>))
 import           Data.Text                          (Text, pack)
@@ -119,16 +120,10 @@ main = do
         host = "127.0.0.1"
         settings = setPort port (setHost host defaultSettings)
         routes = myRoutes static
-        response404 = escapedResponse "<html><head></head><body><h1>404 Not Found</h1></body></html>"
-        resource404 = defaultResource { resourceExists = return False
-                                      , contentTypesProvided = return
-                                            [ ( "text/html"
-                                              , return response404
-                                              )
-                                            ]
-                                      }
-
     mvar <- newMVar HM.empty
     let s = State mvar
     putStrLn "Listening on port 3000"
-    runSettings settings (resourceToWaiT defaultAirshipConfig (const $ flip evalStateT s) routes resource404)
+    runSettings settings (resourceToWaiT defaultAirshipConfig (const $ flip evalStateT s) routes errors)
+    where
+        errors = let response404 = escapedResponse "<html><head></head><body><h1>404 Not Found</h1></body></html>"
+                 in M.singleton HTTP.status404 [("text/html", return response404)]

--- a/example/Versions.hs
+++ b/example/Versions.hs
@@ -8,22 +8,22 @@ module Versions where
 import           Airship
 import           Blaze.ByteString.Builder.ByteString (fromByteString)
 
-import           Control.Applicative                ((<$>))
+import           Control.Applicative                 ((<$>))
 import           Control.Concurrent.MVar
-import           Control.Monad.State                hiding (State)
+import           Control.Monad.State                 hiding (State)
 
-import qualified Data.ByteString.Lazy               as BSL
-import qualified Data.Text as T
+import qualified Data.ByteString.Lazy                as BSL
+import qualified Data.Text                           as T
 
-import qualified Network.HTTP.Types                 as HTTP
-import           Network.Wai.Handler.Warp           (defaultSettings,
-                                                     runSettings, setHost,
-                                                     setPort)
-import qualified Data.Map as M
-import qualified Data.UUID as U
-import qualified Data.UUID.V4 as U
 import           Data.Aeson
-import qualified System.IO as IO
+import qualified Data.Map                            as M
+import qualified Data.UUID                           as U
+import qualified Data.UUID.V4                        as U
+import qualified Network.HTTP.Types                  as HTTP
+import           Network.Wai.Handler.Warp            (defaultSettings,
+                                                      runSettings, setHost,
+                                                      setPort)
+import qualified System.IO                           as IO
 
 -- ***************************************************************************
 -- Basic Data Store
@@ -52,9 +52,9 @@ list t = modifyMVar t $ \m ->
 newtype DirigibleId = DirigibleId { unDirigibleId :: T.Text } deriving (Eq, Show, Ord)
 
 data Dirigible = Dirigible {
-    dName :: T.Text
-  , dEngines :: Int
-  , dCaptain :: Maybe T.Text
+    dName         :: T.Text
+  , dEngines      :: Int
+  , dCaptain      :: Maybe T.Text
   , dLiftCapacity :: Integer
   } deriving (Eq, Show, Ord)
 
@@ -107,18 +107,13 @@ main = do
     let port = 3000
         host = "127.0.0.1"
         settings = setPort port (setHost host defaultSettings)
-        response404 = escapedResponse "<html><head></head><body><h1>404 Not Found</h1></body></html>"
-        resource404 = defaultResource { resourceExists = return False
-                                      , contentTypesProvided = return
-                                            [ ( "text/html"
-                                              , return response404
-                                              )
-                                            ]
-                                      }
     db <- createDb
     insertDirigibles db
     IO.putStrLn "Listening on port 3000"
-    runSettings settings (resourceToWai defaultAirshipConfig (routes db) resource404)
+    runSettings settings (resourceToWai defaultAirshipConfig (routes db) errors)
+    where
+        errors = let response404 = escapedResponse "<html><head></head><body><h1>404 Not Found</h1></body></html>"
+                 in M.singleton HTTP.status404 [("text/html", return response404)]
 
 insertDirigibles :: Db -> IO ()
 insertDirigibles db = do

--- a/example/airship-example.cabal
+++ b/example/airship-example.cabal
@@ -19,6 +19,8 @@ executable              basic
                       , airship
                       , blaze-builder >=0.3 && < 0.5
                       , bytestring
+                      , containers
+                      , http-media
                       , http-types >= 0.7
                       , mtl
                       , text
@@ -36,6 +38,8 @@ executable            versions
                       , airship
                       , blaze-builder >=0.3 && < 0.5
                       , bytestring
+                      , containers
+                      , http-media
                       , http-types >= 0.7
                       , mtl
                       , text
@@ -47,4 +51,3 @@ executable            versions
                       , aeson
                       , wai
                       , warp
-

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -12,6 +12,9 @@ module Airship.Internal.Decision
 import           Airship.Headers                  (addResponseHeader)
 import           Airship.Internal.Date            (parseRfc1123Date,
                                                    utcTimeToRfc1123)
+import           Airship.Internal.Parsers         (parseEtagList)
+import           Airship.Resource                 (PostResponse (..),
+                                                   Resource (..))
 import           Airship.Types                    (Response (..),
                                                    ResponseBody (..),
                                                    Webmachine, etagToByteString,
@@ -20,10 +23,6 @@ import           Airship.Types                    (Response (..),
                                                    pathInfo, putResponseBody,
                                                    request, requestHeaders,
                                                    requestMethod, requestTime)
-
-import           Airship.Internal.Parsers         (parseEtagList)
-import           Airship.Resource                 (PostResponse (..),
-                                                   Resource (..))
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative              ((<$>))
 #endif
@@ -32,6 +31,7 @@ import           Control.Monad.Trans              (lift)
 import           Control.Monad.Trans.State.Strict (StateT (..), evalStateT, get,
                                                    modify)
 import           Control.Monad.Writer.Class       (tell)
+
 
 import           Blaze.ByteString.Builder         (toByteString)
 import           Data.ByteString                  (ByteString, intercalate)

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ImpredicativeTypes  #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -14,9 +15,11 @@ module Airship.Resource
 import           Airship.Types
 
 import           Data.ByteString    (ByteString)
+#if __GLASGOW_HASKELL__ < 710
+import           Data.Monoid        (mempty)
+#endif
 import           Data.Text          (Text)
 import           Data.Time.Clock    (UTCTime)
-
 import           Network.HTTP.Media (MediaType)
 import           Network.HTTP.Types
 
@@ -111,6 +114,7 @@ data Resource m =
              , uriTooLong                :: Webmachine m Bool
                -- | Returns @501 Not Implemented@ if false. Default: true.
              , validContentHeaders       :: Webmachine m Bool
+             , errorResponses            :: ErrorResponses m
              }
 
 -- | A helper function that terminates execution with @500 Internal Server Error@.
@@ -146,4 +150,5 @@ defaultResource = Resource { allowMissingPost          = return False
                            , serviceAvailable          = return True
                            , uriTooLong                = return False
                            , validContentHeaders       = return True
+                           , errorResponses            = mempty
                            }


### PR DESCRIPTION
This is a change that stems from the discussion on #93. That PR was an attempt to fix a bug with returning a custom response body for requests for unmatched routes, but this PR represents a more broad effort to improve handling of requests for unmatched routes and also provide a means to return a custom response body for any error code. 

~~_Note:_ This work is currently incomplete. I have only added handling for the custom responses at `l07` in the decision tree. I'm opening the PR now to garner feedback on the approach before going any further.~~

Here is a short summary of these changes mostly taken from the commit message:
- Do not traverse the decision tree when no route matches. This mimics
  the [behavior of Erlang Webmachine](https://github.com/webmachine/webmachine/blob/master/src/webmachine_mochiweb.erl#L62-L64) and simplifies dealing with such
  requests. 
- Add the ability to specify a mapping of HTTP status codes to pairs of
  content type header values and custom response bodies for an Airship
  application or for an individual resource. The content type value in
  the mapping is used to set the response `Content-Type` header and the
  intention is that the specified content type value match the error
  response body.In the case of conflicts between application-level and
  resource-level error response mappings, the resource-level mappings
  are favored. This also more closely mimics what is offered by Erlang Webmachine.
- Replace the `Resource IO` parameter to `resourceToWai` with an
  ErrorResponses type that represents the mapping from HTTP status code
  to error response data. The 404 resource previously used to handle
  unmatched routes is no longer necessary since requests for unmatched
  routes now bail out early.
