### PR TITLE
Provide a default for contentTypesProvided.

### DIFF
--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -118,7 +118,7 @@ defaultResource :: Monad m => Resource m
 defaultResource = Resource { allowMissingPost          = return False
                            , allowedMethods            = return [methodOptions, methodGet, methodHead]
                            , contentTypesAccepted      = return []
-                           , contentTypesProvided      = return []
+                           , contentTypesProvided      = return [("text/html", halt status405)]
                            , deleteCompleted           = return False
                            , deleteResource            = return False
                            , entityTooLarge            = return False


### PR DESCRIPTION
This brings airship inline with the behaviour of webmachine which provides a default implementation of 

``` erlang
default(content_types_provided) ->
    [{"text/html", to_html}];
default(content_types_accepted) ->
    [];
...
```

https://github.com/webmachine/webmachine/blob/master/src/webmachine_resource.erl#L58-L61

This issue came up in a resource where we were only implementing POST.

``` haskell
aResource c = defaultResource
  { allowedMethods = pure [HTTP.methodPost]
  , contentTypesProvided = return . withVersionJson $ \case
      V1 -> halt HTTP.status405 -- here!
  , contentTypesAccepted = return . withVersionJson $ \case
      V1 ->  doPostStuffHere c
  , processPost = return $ PostCreate []
  }
```

When you run a curl POST against this resource it sets both Content-Type (which is correct) and Accepts (which is "_/_" and possibly shouldn't be set) If you provide no implementation for contentTypesProvided then you'll get a 406 response because `c04` expects a non-empty list.

This change provides a non-empty list for `c04`, where the key of "text/html" is matched against but the function `halt status405` isn't used for a POST. If you do add `methodGET` to `allowedMethods` you'll most likely be overriding the `contentTypesProvided` section anyway.
