### PR TITLE
Add `mapWebmachine` to map wrapped computation

### DIFF
--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -15,7 +15,6 @@ import Data.HashMap.Strict (HashMap, insert)
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
-import Control.Monad.Identity
 import Control.Monad.Writer (Writer, WriterT (..), execWriter)
 import Control.Monad.Writer.Class (MonadWriter)
 


### PR DESCRIPTION
Adds a `mapWebmachine` function in the vein of monad transformer map functions (`mapStateT`, `mapEitherT`, etc). Useful when 'lifting' or 'lowering'  the `m` parameter of  `Webmachine m a`, e.g,

```
mapWebmachine liftIO :: MonadIO m => Webmachine IO a -> Webmachine m a
mapWebmachine (`runReaderT` 42) :: Webmachine (ReaderT Int m) a -> Webmachine m a
```

or the particular use I'm after with `local`

```
mapWebmachine . local :: MonadReader r m => (r -> r) -> Webmachine m a -> Webmachine m a
```

This change does not change functionality or the API.
