### PR TITLE
Remove duplicate cryptohash entry in cabal file

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -44,7 +44,6 @@ library
                       , case-insensitive
                       , containers
                       , cryptohash == 0.11.*
-                      , cryptohash == 0.11.6.*
                       , directory
                       , either >= 4.3 && < 4.6
                       , filepath >= 1.3 && < 1.5


### PR DESCRIPTION
Remove a duplicate entry for cryptohash in the cabal file that snuck in
with the last commit.
