### PR TITLE
Remove space leak and inefficiencies associated with the Airship-Trace header.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,34 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Portions of this software have been extracted from the Snap framework,
+which is licensed under the three-clause BSD license.
+
+Copyright (c) 2009, Snap Framework authors (see CONTRIBUTORS)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the Snap Framework authors nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/airship.cabal
+++ b/airship.cabal
@@ -3,7 +3,7 @@ synopsis:               A Webmachine-inspired HTTP library
 description:            A Webmachine-inspired HTTP library
 homepage:               https://github.com/helium/airship/
 Bug-reports:            https://github.com/helium/airship/issues
-version:                0.6.0
+version:                0.7.0
 license:                MIT
 license-file:           LICENSE
 author:                 Reid Draper and Patrick Thomson
@@ -21,6 +21,7 @@ library
   hs-source-dirs: src
   ghc-options:  -Wall
   exposed-modules:   Airship
+                   , Airship.RST
                    , Airship.Config
                    , Airship.Headers
                    , Airship.Helpers

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -17,7 +17,8 @@ import           Airship.Resource                 (PostResponse (..),
                                                    Resource (..))
 import           Airship.Types                    (Response (..),
                                                    ResponseBody (..),
-                                                   Webmachine, etagToByteString,
+                                                   Webmachine, addTrace,
+                                                   etagToByteString,
                                                    getResponseBody,
                                                    getResponseHeaders, halt,
                                                    pathInfo, putResponseBody,
@@ -30,7 +31,6 @@ import           Control.Monad                    (when)
 import           Control.Monad.Trans              (lift)
 import           Control.Monad.Trans.State.Strict (StateT (..), evalStateT, get,
                                                    modify)
-import           Control.Monad.Writer.Class       (tell)
 
 
 import           Blaze.ByteString.Builder         (toByteString)
@@ -81,8 +81,8 @@ initFlowState = FlowState Nothing
 flow :: Monad m => Resource m -> Webmachine m Response
 flow r = evalStateT (b13 r) initFlowState
 
-trace :: Monad m => Text -> FlowStateT m ()
-trace t = lift $ tell [t]
+trace :: Monad m => ByteString -> FlowStateT m ()
+trace = lift . addTrace
 
 -----------------------------------------------------------------------------
 -- Header value data newtypes

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -20,7 +20,7 @@ module Airship.Internal.Helpers
 import           Control.Applicative
 #endif
 import           Control.Monad             (join)
-import           Data.ByteString           (ByteString)
+import           Data.ByteString           (ByteString, intercalate)
 import qualified Data.ByteString.Lazy      as LB
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 710
@@ -29,7 +29,7 @@ import           Data.Monoid
 import           Data.Foldable             (forM_)
 import qualified Data.HashMap.Strict       as HM
 import qualified Data.Map.Strict           as M
-import           Data.Text                 (Text, intercalate)
+import           Data.Text                 (Text)
 import           Data.Text.Encoding
 import           Data.Time                 (getCurrentTime)
 import           Lens.Micro                ((^.))
@@ -176,8 +176,8 @@ getQuip = do
                 , "shut it down"
                 ]
 
-traceHeader :: [Text] -> ByteString
-traceHeader = encodeUtf8 . intercalate ","
+traceHeader :: [ByteString] -> ByteString
+traceHeader = intercalate ","
 
 -- | Lookup routing parameter and return 500 Internal Server Error if not found.
 -- Not finding the paramter usually means the route doesn't match what

--- a/src/Airship/RST.hs
+++ b/src/Airship/RST.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-
+  RST is like the RWST monad, but has no Writer instance, as Writer leaks space.
+  This file is almost entirely lifted from the Snap framework's implementation.
+-}
+
+module Airship.RST
+       ( RST (..)
+       , evalRST
+       , execRST
+       , mapRST
+       , withRST
+       ) where
+
+import           Control.Applicative         (Alternative (..),
+                                              Applicative (..))
+import           Control.Category            ((.))
+import           Control.Monad               (MonadPlus (..), ap)
+import           Control.Monad.Base          (MonadBase (..))
+import           Control.Monad.Reader        (MonadReader (..))
+import           Control.Monad.State.Class   (MonadState (..))
+import           Control.Monad.Trans         (MonadIO (..), MonadTrans (..))
+import           Control.Monad.Trans.Control (ComposeSt, MonadBaseControl (..),
+                                              MonadTransControl (..),
+                                              defaultLiftBaseWith,
+                                              defaultRestoreM)
+import           Prelude                     (Functor (..), Monad (..), seq,
+                                              ($))
+
+
+newtype RST r s m a = RST { runRST :: r -> s -> m (a, s) }
+
+
+evalRST :: Monad m => RST r s m a -> r -> s -> m a
+evalRST m r s = do
+    (a,_) <- runRST m r s
+    return a
+{-# INLINE evalRST #-}
+
+
+execRST :: Monad m => RST r s m a -> r -> s -> m s
+execRST m r s = do
+    (_,!s') <- runRST m r s
+    return s'
+{-# INLINE execRST #-}
+
+
+withRST :: Monad m => (r' -> r) -> RST r s m a -> RST r' s m a
+withRST f m = RST $ \r' s -> runRST m (f r') s
+{-# INLINE withRST #-}
+
+
+instance (Monad m) => MonadReader r (RST r s m) where
+    ask = RST $ \r s -> return (r,s)
+    local f m = RST $ \r s -> runRST m (f r) s
+
+
+instance (Functor m) => Functor (RST r s m) where
+    fmap f m = RST $ \r s -> fmap (\(a,s') -> (f a, s')) $ runRST m r s
+
+
+instance (Functor m, Monad m) => Applicative (RST r s m) where
+    pure = return
+    (<*>) = ap
+
+
+instance (Functor m, MonadPlus m) => Alternative (RST r s m) where
+    empty = mzero
+    (<|>) = mplus
+
+
+instance (Monad m) => MonadState s (RST r s m) where
+    get   = RST $ \_ s -> return (s,s)
+    put x = RST $ \_ _ -> return ((),x)
+
+
+mapRST :: (m (a, s) -> n (b, s)) -> RST r s m a -> RST r s n b
+mapRST f m = RST $ \r s -> f (runRST m r s)
+
+rwsBind :: Monad m =>
+           RST r s m a
+        -> (a -> RST r s m b)
+        -> RST r s m b
+rwsBind m f = RST go
+  where
+    go r !s = do
+        (a, !s')  <- runRST m r s
+        runRST (f a) r s'
+{-# INLINE rwsBind #-}
+
+instance (Monad m) => Monad (RST r s m) where
+    return a = RST $ \_ s -> return (a, s)
+    (>>=)    = rwsBind
+    fail msg = RST $ \_ _ -> fail msg
+
+
+instance (MonadPlus m) => MonadPlus (RST r s m) where
+    mzero       = RST $ \_ _ -> mzero
+    m `mplus` n = RST $ \r s -> runRST m r s `mplus` runRST n r s
+
+
+instance (MonadIO m) => MonadIO (RST r s m) where
+    liftIO = lift . liftIO
+
+
+instance MonadTrans (RST r s) where
+    lift m = RST $ \_ s -> do
+        a <- m
+        return $ s `seq` (a, s)
+
+
+instance MonadBase b m => MonadBase b (RST r s m) where
+    liftBase = lift . liftBase
+
+
+instance MonadBaseControl b m => MonadBaseControl b (RST r s m) where
+     type StM (RST r s m) a = ComposeSt (RST r s) m a
+     liftBaseWith = defaultLiftBaseWith
+     restoreM = defaultRestoreM
+     {-# INLINE liftBaseWith #-}
+     {-# INLINE restoreM #-}
+
+
+instance MonadTransControl (RST r s) where
+    type StT (RST r s) a = (a, s)
+    liftWith f = RST $ \r s -> do
+        res <- f $ \(RST g) -> g r s
+        return (res, s)
+    restoreT k = RST $ \_ _ -> k
+    {-# INLINE liftWith #-}
+    {-# INLINE restoreT #-}

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -18,6 +18,7 @@ module Airship.Types
     , ResponseState(..)
     , ResponseBody(..)
     , ErrorResponses
+    , addTrace
     , defaultRequest
     , entireRequestBody
     , etagToByteString
@@ -34,10 +35,12 @@ module Airship.Types
     , putResponseBody
     , putResponseBS
     , halt
+    , decisionTrace
     , finishWith
     , (#>)
     ) where
 
+import           Airship.RST
 import           Blaze.ByteString.Builder            (Builder)
 import           Blaze.ByteString.Builder.ByteString (fromByteString)
 import           Blaze.ByteString.Builder.Html.Utf8  (fromHtmlEscapedText)
@@ -51,14 +54,13 @@ import           Control.Monad.Base                  (MonadBase)
 import           Control.Monad.IO.Class              (MonadIO, liftIO)
 import           Control.Monad.Morph
 import           Control.Monad.Reader.Class          (MonadReader, ask)
-import           Control.Monad.State.Class           (MonadState, get, modify)
+import           Control.Monad.State.Class           (MonadState, get, modify,
+                                                      modify')
 import           Control.Monad.Trans.Control         (MonadBaseControl (..))
 import           Control.Monad.Trans.Either          (EitherT (..), left,
                                                       mapEitherT, runEitherT)
-import           Control.Monad.Trans.RWS.Strict      (RWST (..), mapRWST,
-                                                      runRWST)
 import           Control.Monad.Writer.Class          (MonadWriter, tell)
-import           Data.ByteString.Char8
+import           Data.ByteString.Char8               hiding (reverse)
 import           Data.HashMap.Strict                 (HashMap)
 import           Data.Map.Strict                     (Map)
 import           Data.Monoid                         ((<>))
@@ -117,24 +119,24 @@ data ResponseState = ResponseState { stateHeaders  :: ResponseHeaders
                                    , stateBody     :: ResponseBody
                                    , _params       :: HashMap Text Text
                                    , _dispatchPath :: [Text]
+                                   , decisionTrace :: Trace
                                    }
 
-type Trace = [Text]
+type Trace = [ByteString]
 
 type ErrorResponses m = Monad m => Map HTTP.Status [(MediaType, Webmachine m ResponseBody)]
 
 newtype Webmachine m a =
-    Webmachine { getWebmachine :: EitherT Response (RWST RequestReader Trace ResponseState m) a }
+    Webmachine { getWebmachine :: EitherT Response (RST RequestReader ResponseState m) a }
         deriving (Functor, Applicative, Monad, MonadIO, MonadBase b,
                   MonadReader RequestReader,
-                  MonadWriter Trace,
                   MonadState ResponseState)
 
 instance MonadTrans Webmachine where
     lift = Webmachine . EitherT . (>>= return . Right) . lift
 
 newtype StMWebmachine m a = StMWebmachine {
-      unStMWebmachine :: StM (EitherT Response (RWST RequestReader Trace ResponseState m)) a
+      unStMWebmachine :: StM (EitherT Response (RST RequestReader ResponseState m)) a
     }
 
 instance MonadBaseControl b m => MonadBaseControl b (Webmachine m) where
@@ -174,7 +176,7 @@ getResponseBody = stateBody <$> get
 
 -- | Given a new 'ResponseBody', replaces the stored body with the new one.
 putResponseBody :: Monad m => ResponseBody -> Webmachine m ()
-putResponseBody b = modify updateState
+putResponseBody b = modify' updateState
     where updateState rs = rs {stateBody = b}
 
 -- | Stores the provided 'ByteString' as the responseBody. This is a shortcut for
@@ -192,6 +194,10 @@ halt status = finishWith =<< Response <$> return status <*> getResponseHeaders <
 -- | Immediately halts processing and writes the provided 'Response' back to the client.
 finishWith :: Monad m => Response -> Webmachine m a
 finishWith = Webmachine . left
+
+-- | Adds the provided ByteString to the Airship-Trace header.
+addTrace :: Monad m => ByteString -> Webmachine m ()
+addTrace t = modify' (\s -> s { decisionTrace = t : decisionTrace s })
 
 -- | The @#>@ operator provides syntactic sugar for the construction of association lists.
 -- For example, the following assoc list:
@@ -224,14 +230,14 @@ eitherResponse reqDate reqParams dispatched req resource = do
     return (both e, trace)
 
 -- | Map both the return value and wrapped computation @m@.
-mapWebmachine :: ( m1 (Either Response a1, ResponseState, Trace)
-                -> m2 (Either Response a2, ResponseState, Trace) )
+mapWebmachine :: ( m1 (Either Response a1, ResponseState)
+                -> m2 (Either Response a2, ResponseState))
               -> Webmachine m1 a1 -> Webmachine m2 a2
-mapWebmachine f =  Webmachine . (mapEitherT $ mapRWST f) . getWebmachine
+mapWebmachine f =  Webmachine . (mapEitherT $ mapRST f) . getWebmachine
 
 runWebmachine :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request -> Webmachine m a -> m (Either (Response) a, Trace)
 runWebmachine reqDate reqParams dispatched req w = do
-    let startingState = ResponseState [] Empty reqParams dispatched
+    let startingState = ResponseState [] Empty reqParams dispatched []
         requestReader = RequestReader reqDate req
-    (e, _, t) <- runRWST (runEitherT (getWebmachine w)) requestReader startingState
-    return (e, t)
+    (e, s) <- runRST (runEitherT (getWebmachine w)) requestReader startingState
+    return (e, reverse $ decisionTrace s)


### PR DESCRIPTION
This PR contains three optimizations to Airship tracing, which (on my 2014 MBP) yield a 18% gain in requests per second (from ~17000 to ~20000).

Before:

```
Running 30s test @ http://localhost:3000/
  1 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   480.45us  272.68us   9.77ms   92.86%
    Req/Sec    16.80k     1.66k   19.19k    73.67%
  501314 requests in 30.00s, 181.53MB read
Requests/sec:  16709.68
Transfer/sec:      6.05MB
```

After:

```
Running 30s test @ http://localhost:3000/
  1 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   386.71us  187.12us   9.02ms   89.36%
    Req/Sec    20.46k     1.21k   21.62k    90.03%
  612854 requests in 30.10s, 221.91MB read
Requests/sec:  20360.40
Transfer/sec:      7.37MB
```

The three optimizations are as follows:
1) We stop using `RWST`, as its `Writer` component leaks space. We replace it with an `RST` monad, extracted from the Snap framework, that provides assured strictness and an inlined `>>=` implementation. In addition, we use `modify'` rather than `modify` to ensure that the change is applied strictly (this yielded a small but significant increase in throughput).
2) We use `(:)` to add a new item onto the internal list of traces, rather than constructing a new list out of the item and using `mappend`. Though this constructs the list of traces in reverse order, we `reverse` said list before sending it to the client.
3) We use `ByteString` values in the internal trace list so as to avoid the overhead of an unnecessary `decodeUtf8` (since the header value is a `ByteString` anyway).

This significantly reduces the time we spend in `Airship.Internal.Decision.trace`. The code currently in master spends between 5-8% of its time in `trace`, as the following cost-center profile shows:

```
COST CENTRE              MODULE                        %time %alloc

utcTimeToRfc1123         Airship.Internal.Date           9.2    6.5
>>=                      Control.Monad.Trans.Either      7.0    5.0
trace                    Airship.Internal.Decision       5.5    9.9
lift                     Control.Monad.Trans.Either      5.3    7.5
o18                      Airship.Internal.Decision       4.6    6.2
fmap                     Airship.Types                   4.5    6.7
[ omitted ...]
```

After this optimization, it spends less than half that time in `trace`:

```
COST CENTRE              MODULE                        %time %alloc

>>=                      Control.Monad.Trans.Either     21.1   17.6
utcTimeToRfc1123         Airship.Internal.Date           7.9    7.8
lift                     Control.Monad.Trans.Either      7.8    6.8
state                    Airship.Types                   4.9    8.4
socketConnection.sendall Network.Wai.Handler.Warp.Run    3.4    0.1
return.\                 Airship.RST                     2.7    6.8
trace                    Airship.Internal.Decision       2.2    4.1
fmap                     Control.Monad.Trans.Either      2.0    1.9
```

(The presence of `return` in the above trace is a red herring: the original implementation would have a similarly significant chunk of `RWST` `return`s, but I compiled without library profiling so as to provide more readable profiles.)

These tests were performed on the `basic` application provided in the Airship distribution, with the `wrk` tool: `wrk -t1 -c8 -d30s http://localhost:3000/`. The application itself was run with three cores, using `stack exec basic -- +RTS -N3 -RTS`. The memory footprint of the `basic` application remains constant at ~8MB. 
