### PR TITLE
Unroll the internal Webmachine monad.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,34 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Portions of this software have been extracted from the Snap framework,
+which is licensed under the three-clause BSD license.
+
+Copyright (c) 2009, Snap Framework authors (see CONTRIBUTORS)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the Snap Framework authors nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/airship.cabal
+++ b/airship.cabal
@@ -3,7 +3,7 @@ synopsis:               A Webmachine-inspired HTTP library
 description:            A Webmachine-inspired HTTP library
 homepage:               https://github.com/helium/airship/
 Bug-reports:            https://github.com/helium/airship/issues
-version:                0.6.0
+version:                0.7.0
 license:                MIT
 license-file:           LICENSE
 author:                 Reid Draper and Patrick Thomson
@@ -21,6 +21,7 @@ library
   hs-source-dirs: src
   ghc-options:  -Wall
   exposed-modules:   Airship
+                   , Airship.RST
                    , Airship.Config
                    , Airship.Headers
                    , Airship.Helpers

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -17,7 +17,8 @@ import           Airship.Resource                 (PostResponse (..),
                                                    Resource (..))
 import           Airship.Types                    (Response (..),
                                                    ResponseBody (..),
-                                                   Webmachine, etagToByteString,
+                                                   Webmachine, addTrace,
+                                                   etagToByteString,
                                                    getResponseBody,
                                                    getResponseHeaders, halt,
                                                    pathInfo, putResponseBody,
@@ -30,7 +31,6 @@ import           Control.Monad                    (when)
 import           Control.Monad.Trans              (lift)
 import           Control.Monad.Trans.State.Strict (StateT (..), evalStateT, get,
                                                    modify)
-import           Control.Monad.Writer.Class       (tell)
 
 
 import           Blaze.ByteString.Builder         (toByteString)
@@ -81,8 +81,8 @@ initFlowState = FlowState Nothing
 flow :: Monad m => Resource m -> Webmachine m Response
 flow r = evalStateT (b13 r) initFlowState
 
-trace :: Monad m => Text -> FlowStateT m ()
-trace t = lift $ tell [t]
+trace :: Monad m => ByteString -> FlowStateT m ()
+trace a = lift $ addTrace a
 
 -----------------------------------------------------------------------------
 -- Header value data newtypes

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -20,7 +20,7 @@ module Airship.Internal.Helpers
 import           Control.Applicative
 #endif
 import           Control.Monad             (join)
-import           Data.ByteString           (ByteString)
+import           Data.ByteString           (ByteString, intercalate)
 import qualified Data.ByteString.Lazy      as LB
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 710
@@ -29,7 +29,7 @@ import           Data.Monoid
 import           Data.Foldable             (forM_)
 import qualified Data.HashMap.Strict       as HM
 import qualified Data.Map.Strict           as M
-import           Data.Text                 (Text, intercalate)
+import           Data.Text                 (Text)
 import           Data.Text.Encoding
 import           Data.Time                 (getCurrentTime)
 import           Lens.Micro                ((^.))
@@ -176,8 +176,8 @@ getQuip = do
                 , "shut it down"
                 ]
 
-traceHeader :: [Text] -> ByteString
-traceHeader = encodeUtf8 . intercalate ","
+traceHeader :: [ByteString] -> ByteString
+traceHeader = intercalate ","
 
 -- | Lookup routing parameter and return 500 Internal Server Error if not found.
 -- Not finding the paramter usually means the route doesn't match what

--- a/src/Airship/RST.hs
+++ b/src/Airship/RST.hs
@@ -1,0 +1,162 @@
+{-
+  This file is copyright (c) 2009, the Snap Framework authors,
+  and Patrick Thomson (for the Airship project).
+  Used under the three-clause BSD license, the text of which may be
+  found in the LICENSE file in the Airship root.
+-}
+
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-
+  RST is like the RWST monad, but has no Writer instance, as Writer leaks space.
+  This file is almost entirely lifted from the Snap framework's implementation.
+-}
+
+module Airship.RST
+       ( RST (..)
+       , evalRST
+       , execRST
+       , mapRST
+       , withRST
+       , failure
+       ) where
+
+import           Control.Applicative         (Alternative (..),
+                                              Applicative (..))
+import           Control.Category            ((.))
+import           Control.Monad               (MonadPlus (..), ap)
+import           Control.Monad.Base          (MonadBase (..))
+import           Control.Monad.Reader        (MonadReader (..))
+import           Control.Monad.State.Class   (MonadState (..))
+import           Control.Monad.Trans         (MonadIO (..), MonadTrans (..))
+import           Control.Monad.Trans.Control (ComposeSt, MonadBaseControl (..),
+                                              MonadTransControl (..),
+                                              defaultLiftBaseWith,
+                                              defaultRestoreM)
+import           Data.Either
+import           Prelude                     (Functor (..), Monad (..), seq,
+                                              ($), ($!))
+
+
+newtype RST r s e m a = RST { runRST :: r -> s -> m (Either e a, s) }
+
+
+evalRST :: Monad m => RST r s e m a -> r -> s -> m (Either e a)
+evalRST m r s = do
+    (res, _) <- runRST m r s
+    return $! res
+{-# INLINE evalRST #-}
+
+
+execRST :: Monad m => RST r s e m a -> r -> s -> m s
+execRST m r s = do
+    (_,!s') <- runRST m r s
+    return $! s'
+{-# INLINE execRST #-}
+
+
+withRST :: Monad m => (r' -> r) -> RST r s e m a -> RST r' s e m a
+withRST f m = RST $ \r' s -> runRST m (f r') s
+{-# INLINE withRST #-}
+
+
+instance (Monad m) => MonadReader r (RST r s e m) where
+    ask = RST $ \r s -> return $! (Right r,s)
+    local f m = RST $ \r s -> runRST m (f r) s
+
+-- Terrible hack to work around the fact that Functor isn't a superclass
+-- of Monad on GHC 7.8. TODO kill this when 7.8 support is dropped
+#if __GLASGOW_HASKELL__ == 708
+instance (Monad m) => Functor (RST r s e m) where
+    fmap f m = RST $ \r s -> runRST m r s >>= helper where
+      helper (a, s') = case a of
+          (Left l) -> return $! (Left l, s')
+          (Right r) -> return $! (Right $ f r, s')
+#else
+instance (Functor m) => Functor (RST r s e m) where
+    fmap f m = RST $ \r s -> fmap (\(a,s') -> (fmap f a, s')) $ runRST m r s
+#endif
+
+instance Monad m => Applicative (RST r s e m) where
+    pure = return
+    (<*>) = ap
+
+
+instance MonadPlus m => Alternative (RST r s e m) where
+    empty = mzero
+    (<|>) = mplus
+
+
+instance (Monad m) => MonadState s (RST r s e m) where
+    get   = RST $ \_ s -> return $! (Right s,s)
+    put x = RST $ \_ _ -> return $! (Right (),x)
+    state act = RST $ \_ s -> do
+      let (res, !s') = act s
+      return $! (Right res, s')
+
+
+mapRST :: (m (Either e a, s) -> n (Either e b, s)) -> RST r s e m a -> RST r s e n b
+mapRST f m = RST $ \r s -> f (runRST m r s)
+
+rwsBind :: Monad m =>
+           RST r s e m a
+        -> (a -> RST r s e m b)
+        -> RST r s e m b
+rwsBind m f = RST go
+  where
+    go r !s = do
+        (a, !s')  <- runRST m r s
+        case a of
+            Left e  -> return $! (Left e, s')
+            Right a' ->  runRST (f a') r s'
+{-# INLINE rwsBind #-}
+
+instance (Monad m) => Monad (RST r s e m) where
+    return a = RST $ \_ s -> return $! (Right a, s)
+    (>>=)    = rwsBind
+    fail msg = RST $ \_ _ -> fail msg
+
+
+instance (MonadPlus m) => MonadPlus (RST r s e m) where
+    mzero       = RST $ \_ _ -> mzero
+    m `mplus` n = RST $ \r s -> runRST m r s `mplus` runRST n r s
+
+
+instance (MonadIO m) => MonadIO (RST r s e m) where
+    liftIO = lift . liftIO
+
+
+instance MonadTrans (RST r s e) where
+    lift m = RST $ \_ s -> do
+        a <- m
+        return $ s `seq` (Right a, s)
+
+
+instance MonadBase b m => MonadBase b (RST r s e m) where
+    liftBase = lift . liftBase
+
+
+instance MonadBaseControl b m => MonadBaseControl b (RST r s e m) where
+     type StM (RST r s e m) a = ComposeSt (RST r s e) m a
+     liftBaseWith = defaultLiftBaseWith
+     restoreM = defaultRestoreM
+     {-# INLINE liftBaseWith #-}
+     {-# INLINE restoreM #-}
+
+instance MonadTransControl (RST r s e) where
+    type StT (RST r s e) a = (Either e a, s)
+    liftWith f = RST $ \r s -> do
+        res <- f $ \(RST g) -> g r s
+        return $! (Right res, s)
+    restoreT k = RST $ \_ _ -> k
+    {-# INLINE liftWith #-}
+    {-# INLINE restoreT #-}
+
+failure :: Monad m => e -> RST r s e m a
+failure e = RST $ \_ s -> return $! (Left e, s)

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -18,6 +18,7 @@ module Airship.Types
     , ResponseState(..)
     , ResponseBody(..)
     , ErrorResponses
+    , addTrace
     , defaultRequest
     , entireRequestBody
     , etagToByteString
@@ -34,10 +35,12 @@ module Airship.Types
     , putResponseBody
     , putResponseBS
     , halt
+    , decisionTrace
     , finishWith
     , (#>)
     ) where
 
+import           Airship.RST
 import           Blaze.ByteString.Builder            (Builder)
 import           Blaze.ByteString.Builder.ByteString (fromByteString)
 import           Blaze.ByteString.Builder.Html.Utf8  (fromHtmlEscapedText)
@@ -51,14 +54,12 @@ import           Control.Monad.Base                  (MonadBase)
 import           Control.Monad.IO.Class              (MonadIO, liftIO)
 import           Control.Monad.Morph
 import           Control.Monad.Reader.Class          (MonadReader, ask)
-import           Control.Monad.State.Class           (MonadState, get, modify)
+import           Control.Monad.State.Class
 import           Control.Monad.Trans.Control         (MonadBaseControl (..))
 import           Control.Monad.Trans.Either          (EitherT (..), left,
                                                       mapEitherT, runEitherT)
-import           Control.Monad.Trans.RWS.Strict      (RWST (..), mapRWST,
-                                                      runRWST)
 import           Control.Monad.Writer.Class          (MonadWriter, tell)
-import           Data.ByteString.Char8
+import           Data.ByteString.Char8               hiding (reverse)
 import           Data.HashMap.Strict                 (HashMap)
 import           Data.Map.Strict                     (Map)
 import           Data.Monoid                         ((<>))
@@ -117,24 +118,27 @@ data ResponseState = ResponseState { stateHeaders  :: ResponseHeaders
                                    , stateBody     :: ResponseBody
                                    , _params       :: HashMap Text Text
                                    , _dispatchPath :: [Text]
+                                   , decisionTrace :: Trace
                                    }
 
-type Trace = [Text]
+type Trace = [ByteString]
 
 type ErrorResponses m = Monad m => Map HTTP.Status [(MediaType, Webmachine m ResponseBody)]
 
 newtype Webmachine m a =
-    Webmachine { getWebmachine :: EitherT Response (RWST RequestReader Trace ResponseState m) a }
+    Webmachine { getWebmachine :: (RST RequestReader ResponseState Response m) a }
         deriving (Functor, Applicative, Monad, MonadIO, MonadBase b,
                   MonadReader RequestReader,
-                  MonadWriter Trace,
                   MonadState ResponseState)
 
 instance MonadTrans Webmachine where
-    lift = Webmachine . EitherT . (>>= return . Right) . lift
+    lift = Webmachine . RST . helper where
+      helper m _ s = do
+          a <- m
+          return $ (Right a, s)
 
 newtype StMWebmachine m a = StMWebmachine {
-      unStMWebmachine :: StM (EitherT Response (RWST RequestReader Trace ResponseState m)) a
+      unStMWebmachine :: StM (RST RequestReader ResponseState Response m) a
     }
 
 instance MonadBaseControl b m => MonadBaseControl b (Webmachine m) where
@@ -145,6 +149,14 @@ instance MonadBaseControl b m => MonadBaseControl b (Webmachine m) where
                      $ \m -> liftM StMWebmachine
                      $ g' $ getWebmachine m
   restoreM = Webmachine . restoreM . unStMWebmachine
+
+-- Work around old versions of mtl not having a strict modify function
+modify'' :: MonadState s m => (s -> s) -> m ()
+#if MIN_VERSION_mtl(2,2,0)
+modify'' = modify'
+#else
+modify'' f = state (\s -> let s' = f s in s' `seq` ((), s'))
+#endif
 
 -- Functions inside the Webmachine Monad -------------------------------------
 ------------------------------------------------------------------------------
@@ -174,7 +186,7 @@ getResponseBody = stateBody <$> get
 
 -- | Given a new 'ResponseBody', replaces the stored body with the new one.
 putResponseBody :: Monad m => ResponseBody -> Webmachine m ()
-putResponseBody b = modify updateState
+putResponseBody b = modify'' updateState
     where updateState rs = rs {stateBody = b}
 
 -- | Stores the provided 'ByteString' as the responseBody. This is a shortcut for
@@ -191,7 +203,11 @@ halt status = finishWith =<< Response <$> return status <*> getResponseHeaders <
 
 -- | Immediately halts processing and writes the provided 'Response' back to the client.
 finishWith :: Monad m => Response -> Webmachine m a
-finishWith = Webmachine . left
+finishWith = Webmachine . failure
+
+-- | Adds the provided ByteString to the Airship-Trace header.
+addTrace :: Monad m => ByteString -> Webmachine m ()
+addTrace t = modify'' (\s -> s { decisionTrace = t : decisionTrace s })
 
 -- | The @#>@ operator provides syntactic sugar for the construction of association lists.
 -- For example, the following assoc list:
@@ -224,14 +240,14 @@ eitherResponse reqDate reqParams dispatched req resource = do
     return (both e, trace)
 
 -- | Map both the return value and wrapped computation @m@.
-mapWebmachine :: ( m1 (Either Response a1, ResponseState, Trace)
-                -> m2 (Either Response a2, ResponseState, Trace) )
+mapWebmachine :: ( m1 (Either Response a1, ResponseState)
+                -> m2 (Either Response a2, ResponseState))
               -> Webmachine m1 a1 -> Webmachine m2 a2
-mapWebmachine f =  Webmachine . (mapEitherT $ mapRWST f) . getWebmachine
+mapWebmachine f =  Webmachine . (mapRST f) . getWebmachine
 
-runWebmachine :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request -> Webmachine m a -> m (Either (Response) a, Trace)
+runWebmachine :: Monad m => UTCTime -> HashMap Text Text -> [Text] -> Request -> Webmachine m a -> m (Either Response a, Trace)
 runWebmachine reqDate reqParams dispatched req w = do
-    let startingState = ResponseState [] Empty reqParams dispatched
+    let startingState = ResponseState [] Empty reqParams dispatched []
         requestReader = RequestReader reqDate req
-    (e, _, t) <- runRWST (runEitherT (getWebmachine w)) requestReader startingState
-    return (e, t)
+    (e, s) <- runRST (getWebmachine w) requestReader startingState
+    return (e, reverse $ decisionTrace s)

--- a/stack-ghc7.8.yaml
+++ b/stack-ghc7.8.yaml
@@ -1,0 +1,8 @@
+flags: {}
+packages:
+- ./
+- example
+extra-deps:
+- microlens-0.3.4.1
+- http-types-0.9
+resolver: lts-2.2


### PR DESCRIPTION
This PR contains four optimizations to Airship's internal monad and tracing mechanisms, which (on my 2014 MBP) yield a **82%** gain in requests per second (from ~17000 to ~30000).

Before:

```
Running 30s test @ http://localhost:3000/
  1 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   480.45us  272.68us   9.77ms   92.86%
    Req/Sec    16.80k     1.66k   19.19k    73.67%
  501314 requests in 30.00s, 181.53MB read
Requests/sec:  16709.68
Transfer/sec:      6.05MB
```

After:

```
Running 30s test @ http://localhost:3000/
  1 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   250.78us   95.39us   5.48ms   77.80%
    Req/Sec    30.64k     1.02k   32.02k    83.00%
  914337 requests in 30.00s, 331.10MB read
Requests/sec:  30477.75
Transfer/sec:     11.04MB
```

The three optimizations are as follows:
1) We stop using `RWST`, as its `Writer` component leaks space. We replace it with an `RST` monad, extracted from the Snap framework, that provides assured strictness and an inlined `>>=` implementation. In addition, we use `modify'` rather than `modify` to ensure that the change is applied strictly (this yielded a small but significant increase in throughput).
2) We remove EitherT from our monad transformer, putting an Either inside the state tuple to represent failure.
3) We use `(:)` to add a new item onto the internal list of traces, rather than constructing a new list out of the item and using `mappend`. Though this constructs the list of traces in reverse order, we `reverse` said list before sending it to the client.
4) We use `ByteString` values in the internal trace list so as to avoid the overhead of an unnecessary `decodeUtf8` (since the header value is a `ByteString` anyway).

This significantly reduces the time we spend in `Airship.Internal.Decision.trace`. The code currently in master spends between 5-8% of its time in `trace`, as the following cost-center profile shows:

```
COST CENTRE              MODULE                        %time %alloc

utcTimeToRfc1123         Airship.Internal.Date           9.2    6.5
>>=                      Control.Monad.Trans.Either      7.0    5.0
trace                    Airship.Internal.Decision       5.5    9.9
lift                     Control.Monad.Trans.Either      5.3    7.5
o18                      Airship.Internal.Decision       4.6    6.2
fmap                     Airship.Types                   4.5    6.7
[ omitted ...]
```

After this optimization, it spends less time and memory in `trace`, `fmap`, and `lift` (inlining `trace` did not improve performance when compiled with -O2):

```
COST CENTRE              MODULE                        %time %alloc

COST CENTRE              MODULE                        %time %alloc
utcTimeToRfc1123         Airship.Internal.Date          13.4   15.5
trace                    Airship.Internal.Decision       5.3    6.0
socketConnection.sendall Network.Wai.Handler.Warp.Run    5.2    0.3
b13                      Airship.Internal.Decision       4.3    4.9
o18                      Airship.Internal.Decision       4.0    4.4
lift.\                   Airship.RST                     3.0    1.7
fmap.\                   Airship.RST                     2.9    4.9
state.\                  Airship.RST                     2.6    7.1
receiveloop              Network.Wai.Handler.Warp.Recv   2.2    0.0
traceHeader              Airship.Internal.Helpers        1.8    4.4
```

These tests were performed on the `basic` application provided in the Airship distribution, with the `wrk` tool: `wrk -t1 -c8 -d30s http://localhost:3000/`. The application itself was run with three cores, using `stack exec basic -- +RTS -N3 -RTS`. The memory footprint of the `basic` application remains constant at ~8MB. 
