### PR TITLE
Handle unspecified content type

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -3,7 +3,7 @@ synopsis:               A Webmachine-inspired HTTP library
 description:            A Webmachine-inspired HTTP library
 homepage:               https://github.com/helium/airship/
 Bug-reports:            https://github.com/helium/airship/issues
-version:                0.6.0
+version:                0.6.1
 license:                MIT
 license-file:           LICENSE
 author:                 Reid Draper and Patrick Thomson

--- a/src/Airship/Internal/Decision.hs
+++ b/src/Airship/Internal/Decision.hs
@@ -35,7 +35,7 @@ import           Control.Monad.Writer.Class       (tell)
 
 import           Blaze.ByteString.Builder         (toByteString)
 import           Data.ByteString                  (ByteString, intercalate)
-import           Data.Maybe                       (isJust)
+import           Data.Maybe                       (fromMaybe, isJust)
 import           Data.Text                        (Text)
 import           Data.Time.Clock                  (UTCTime)
 
@@ -99,9 +99,8 @@ negotiateContentTypesAccepted :: Monad m => [(MediaType, Webmachine m a)] -> Flo
 negotiateContentTypesAccepted accepted = do
     req <- lift request
     let reqHeaders = requestHeaders req
-        result = do
-            cType <- lookup HTTP.hContentType reqHeaders
-            mapContentMedia accepted cType
+        cType = "application/octet-stream" `fromMaybe` (lookup HTTP.hContentType reqHeaders)
+        result = mapContentMedia accepted cType
     case result of
         (Just process) -> lift process
         Nothing -> lift $ halt HTTP.status415


### PR DESCRIPTION
Defaults to `application/octet-stream` in `n11` if the Content-Type header is not provided.
