### PR TITLE
Unroll the internal Webmachine monad.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,34 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Portions of this software have been extracted from the Snap framework,
+which is licensed under the three-clause BSD license.
+
+Copyright (c) 2009, Snap Framework authors (see CONTRIBUTORS)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the Snap Framework authors nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/airship.cabal
+++ b/airship.cabal
@@ -3,7 +3,7 @@ synopsis:               A Webmachine-inspired HTTP library
 description:            A Webmachine-inspired HTTP library
 homepage:               https://github.com/helium/airship/
 Bug-reports:            https://github.com/helium/airship/issues
-version:                0.6.1
+version:                0.7.0
 license:                MIT
 license-file:           LICENSE
 author:                 Reid Draper and Patrick Thomson
@@ -21,6 +21,7 @@ library
   hs-source-dirs: src
   ghc-options:  -Wall
   exposed-modules:   Airship
+                   , Airship.RST
                    , Airship.Config
                    , Airship.Headers
                    , Airship.Helpers

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -20,7 +20,7 @@ module Airship.Internal.Helpers
 import           Control.Applicative
 #endif
 import           Control.Monad             (join)
-import           Data.ByteString           (ByteString)
+import           Data.ByteString           (ByteString, intercalate)
 import qualified Data.ByteString.Lazy      as LB
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 710
@@ -29,8 +29,7 @@ import           Data.Monoid
 import           Data.Foldable             (forM_)
 import qualified Data.HashMap.Strict       as HM
 import qualified Data.Map.Strict           as M
-import           Data.Text                 (Text, intercalate)
-import           Data.Text.Encoding
+import           Data.Text                 (Text)
 import           Data.Time                 (getCurrentTime)
 import           Lens.Micro                ((^.))
 import           Network.HTTP.Media
@@ -176,8 +175,8 @@ getQuip = do
                 , "shut it down"
                 ]
 
-traceHeader :: [Text] -> ByteString
-traceHeader = encodeUtf8 . intercalate ","
+traceHeader :: [ByteString] -> ByteString
+traceHeader = intercalate ","
 
 -- | Lookup routing parameter and return 500 Internal Server Error if not found.
 -- Not finding the paramter usually means the route doesn't match what

--- a/src/Airship/RST.hs
+++ b/src/Airship/RST.hs
@@ -1,0 +1,161 @@
+{-
+  This file is copyright (c) 2009, the Snap Framework authors,
+  and Patrick Thomson (for the Airship project).
+  Used under the three-clause BSD license, the text of which may be
+  found in the LICENSE file in the Airship root.
+-}
+
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-
+  RST is like the RWST monad, but has no Writer instance, as Writer leaks space.
+  This file is almost entirely lifted from the Snap framework's implementation.
+-}
+
+module Airship.RST
+       ( RST (..)
+       , evalRST
+       , execRST
+       , mapRST
+       , withRST
+       , failure
+       ) where
+
+import           Control.Applicative         (Alternative (..),
+                                              Applicative (..))
+import           Control.Category            ((.))
+import           Control.Monad               (MonadPlus (..), ap)
+import           Control.Monad.Base          (MonadBase (..))
+import           Control.Monad.Reader        (MonadReader (..))
+import           Control.Monad.State.Class   (MonadState (..))
+import           Control.Monad.Trans         (MonadIO (..), MonadTrans (..))
+import           Control.Monad.Trans.Control (ComposeSt, MonadBaseControl (..),
+                                              MonadTransControl (..),
+                                              defaultLiftBaseWith,
+                                              defaultRestoreM)
+import           Data.Either
+import           Prelude                     (Functor (..), Monad (..), seq,
+                                              ($), ($!))
+
+
+newtype RST r s e m a = RST { runRST :: r -> s -> m (Either e a, s) }
+
+
+evalRST :: Monad m => RST r s e m a -> r -> s -> m (Either e a)
+evalRST m r s = do
+    (res, _) <- runRST m r s
+    return $! res
+{-# INLINE evalRST #-}
+
+
+execRST :: Monad m => RST r s e m a -> r -> s -> m s
+execRST m r s = do
+    (_,!s') <- runRST m r s
+    return $! s'
+{-# INLINE execRST #-}
+
+
+withRST :: Monad m => (r' -> r) -> RST r s e m a -> RST r' s e m a
+withRST f m = RST $ \r' s -> runRST m (f r') s
+{-# INLINE withRST #-}
+
+
+instance (Monad m) => MonadReader r (RST r s e m) where
+    ask = RST $ \r s -> return $! (Right r,s)
+    local f m = RST $ \r s -> runRST m (f r) s
+
+-- Terrible hack to work around the fact that Functor isn't a superclass
+-- of Monad on GHC 7.8. TODO kill this when 7.8 support is dropped
+#if __GLASGOW_HASKELL__ == 708
+instance (Monad m) => Functor (RST r s e m) where
+    fmap f m = RST $ \r s -> runRST m r s >>= helper where
+      helper (a, s') = case a of
+          (Left l) -> return $! (Left l, s')
+          (Right r) -> return $! (Right $ f r, s')
+#else
+instance (Functor m) => Functor (RST r s e m) where
+    fmap f m = RST $ \r s -> fmap (\(a,s') -> (fmap f a, s')) $ runRST m r s
+#endif
+
+instance Monad m => Applicative (RST r s e m) where
+    pure = return
+    (<*>) = ap
+
+
+instance MonadPlus m => Alternative (RST r s e m) where
+    empty = mzero
+    (<|>) = mplus
+
+
+instance (Monad m) => MonadState s (RST r s e m) where
+    get   = RST $ \_ s -> return $! (Right s,s)
+    put x = RST $ \_ _ -> return $! (Right (),x)
+    state act = RST $ \_ s -> do
+      let (res, !s') = act s
+      return $! (Right res, s')
+
+
+mapRST :: (m (Either e a, s) -> n (Either e b, s)) -> RST r s e m a -> RST r s e n b
+mapRST f m = RST $ \r s -> f (runRST m r s)
+
+rwsBind :: Monad m =>
+           RST r s e m a
+        -> (a -> RST r s e m b)
+        -> RST r s e m b
+rwsBind m f = RST go
+  where
+    go r !s = do
+        (a, !s')  <- runRST m r s
+        case a of
+            Left e  -> return $! (Left e, s')
+            Right a' ->  runRST (f a') r s'
+{-# INLINE rwsBind #-}
+
+instance (Monad m) => Monad (RST r s e m) where
+    return a = RST $ \_ s -> return $! (Right a, s)
+    (>>=)    = rwsBind
+    fail msg = RST $ \_ _ -> fail msg
+
+
+instance (MonadPlus m) => MonadPlus (RST r s e m) where
+    mzero       = RST $ \_ _ -> mzero
+    m `mplus` n = RST $ \r s -> runRST m r s `mplus` runRST n r s
+
+
+instance (MonadIO m) => MonadIO (RST r s e m) where
+    liftIO = lift . liftIO
+
+
+instance MonadTrans (RST r s e) where
+    lift m = RST $ \_ s -> do
+        a <- m
+        return $ s `seq` (Right a, s)
+
+
+instance MonadBase b m => MonadBase b (RST r s e m) where
+    liftBase = lift . liftBase
+
+
+instance MonadBaseControl b m => MonadBaseControl b (RST r s e m) where
+     type StM (RST r s e m) a = ComposeSt (RST r s e) m a
+     liftBaseWith = defaultLiftBaseWith
+     restoreM = defaultRestoreM
+     {-# INLINE liftBaseWith #-}
+     {-# INLINE restoreM #-}
+
+instance MonadTransControl (RST r s e) where
+    type StT (RST r s e) a = (Either e a, s)
+    liftWith f = RST $ \r s -> do
+        res <- f $ \(RST g) -> g r s
+        return $! (Right res, s)
+    restoreT k = RST $ \_ _ -> k
+    {-# INLINE liftWith #-}
+    {-# INLINE restoreT #-}
+
+failure :: Monad m => e -> RST r s e m a
+failure e = RST $ \_ s -> return $! (Left e, s)

--- a/stack-ghc7.8.yaml
+++ b/stack-ghc7.8.yaml
@@ -1,0 +1,8 @@
+flags: {}
+packages:
+- ./
+- example
+extra-deps:
+- microlens-0.3.4.1
+- http-types-0.9
+resolver: lts-2.2


### PR DESCRIPTION
This patch contains four optimizations:

1) We stop using RWST, as its Writer component leaks space. We replace
it with an RST monad, extracted from the Snap framework, that provides
assured strictness and an inlined >>= implementation. In addition, we
use modify' rather than modify to ensure that the change is applied
strictly (this yielded a small but significant increase in throughput).

2) We stop using EitherT, instead electing to use an Either type in
the internal runRST function, maintaining strictness all the while.

3) We use (:) to add a new item onto the internal list of traces,
rather than constructing a new list out of the item and using mappend.
Though this constructs the list of traces in reverse order, we reverse
said list before sending it to the client.

4) We use ByteString values in the internal trace list so as to avoid
the overhead of an unnecessary decodeUtf8 (since the header value is
a ByteString anyway).
