### PR TITLE
Update the routing data structure

### DIFF
--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -113,7 +113,7 @@ resourceToWaiT :: Monad m =>
                -> Wai.Application
 resourceToWaiT cfg run routes errors req respond = do
     let routeMapping = runRouter routes
-        pInfo = Wai.pathInfo req
+        pInfo = Wai.rawPathInfo req
     quip <- getQuip
     nowTime <- getCurrentTime
     let (er, (ps, matched), r) =

--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString            as B
 import qualified Data.ByteString.Base64     as Base64
 import qualified Data.ByteString.Char8      as BC8
 import           Data.HashMap.Strict        (HashMap, fromList)
-import qualified Data.List                  as L (foldr)
+import qualified Data.List                  as L (foldl')
 import           Data.Maybe                 (isNothing)
 import           Data.Monoid
 import           Data.Text                  (Text)
@@ -56,9 +56,9 @@ runRouter routes = toTrie $ execWriter (getRouter routes)
         -- in the desired manner. In the case of duplicate routes the
         -- routes specified first are favored over any subsequent
         -- specifications.
-        toTrie = L.foldr (uncurry insertOrReplace) Trie.empty
-        insertOrReplace k v t =
-            let newV = maybe v (`mergeValues` v) $ Trie.lookup k t
+        toTrie = L.foldl' insertOrReplace Trie.empty
+        insertOrReplace t (k, v) =
+            let newV = maybe v (mergeValues v) $ Trie.lookup k t
             in Trie.insert k newV t
         mergeValues (Wildcard x) _                              = Wildcard x
         mergeValues _ (Wildcard x)                                     = Wildcard x

--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -1,22 +1,32 @@
-{-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# OPTIONS_HADDOCK hide                #-}
 
 module Airship.Internal.Route where
 
-import           Airship.Resource
+import           Airship.Resource           as Resource
 
-import           Data.Foldable              (foldr')
-import           Data.HashMap.Strict        (HashMap, insert)
+import           Control.Monad.Writer.Class (MonadWriter, tell)
+import           Crypto.Hash.SHA256
+import qualified Data.ByteString            as B
+import qualified Data.ByteString.Char8      as BC8
+import           Data.HashMap.Strict        (HashMap, fromList)
+import           Data.Maybe                 (isNothing)
 import           Data.Monoid
 import           Data.Text                  (Text)
+import qualified Data.Text                  as T (pack, unpack)
+import           Data.Trie                  (Trie)
+import qualified Data.Trie                  as Trie
+
 
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
 import           Control.Monad.Writer       (Writer, WriterT (..), execWriter)
-import           Control.Monad.Writer.Class (MonadWriter)
 
 import           Data.String                (IsString, fromString)
 
@@ -32,7 +42,25 @@ data BoundOrUnbound = Bound Text
 instance IsString Route where
     fromString s = Route [Bound (fromString s)]
 
-runRouter :: RoutingSpec m a -> [(Route, Resource m)]
+
+data RouteLeaf m = RouteMatch (Resource m) [Text]
+                 | RVar
+                 | RouteMatchOrVar (Resource m) [Text]
+                 | Wildcard (Resource m)
+
+instance Monad m => Monoid (RouteLeaf m) where
+    mempty                                    = RVar
+    mappend RVar RVar                         = RVar
+    mappend (Wildcard x) _                    = Wildcard x
+    mappend _ (Wildcard x)                    = Wildcard x
+    mappend (RouteMatch x y) (RouteMatch _ _) = RouteMatch x y
+    mappend (RouteMatch x y) RVar             = RouteMatchOrVar x y
+    mappend RVar (RouteMatch x y)             = RouteMatchOrVar x y
+    mappend (RouteMatchOrVar x y) _           = RouteMatchOrVar x y
+    mappend _ (RouteMatchOrVar x y)           = RouteMatchOrVar x y
+
+
+runRouter :: RoutingSpec m a -> Trie (RouteLeaf m)
 runRouter routes = execWriter (getRouter routes)
 
 -- | @a '</>' b@ separates the path components @a@ and @b@ with a slash.
@@ -65,6 +93,41 @@ var t = Route [Var t]
 star :: Route
 star = Route [RestUnbound]
 
+
+-- Routing trie creation algorithm
+-- 1. Store full paths as keys up to first `var`
+-- 2. Take SHA256 digest of the URL portion preceding the
+--    `var` ++ "var" and use that as key for the next part of the
+--    route spec.
+-- 3. Repeat step 2 for every `var` encountered until the route
+ --   is completed and maps to a resource.
+(#>) :: forall m a. MonadWriter (Trie (RouteLeaf a)) m
+     => Route -> Resource a -> m ()
+k #> v = do
+    let (key, routeTrie, vars, isWild) = foldl routeFoldFun ("", Trie.empty, [], False) (getRoute k)
+        key' = if BC8.null key then "/"
+               else key
+        ctor = if isWild then Wildcard v
+               else RouteMatch v vars
+    tell $ Trie.insert key' ctor routeTrie
+    where
+        routeFoldFun (kps, rt, vs, False) (Bound x) =
+            (B.concat [kps, "/", toBS x], rt, vs, False)
+        routeFoldFun (kps, rt, vs, False) (Var x) =
+            let partKey = hash $ B.concat [kps, "var"]
+                rt' = Trie.insert kps RVar rt
+            in (partKey, rt', x:vs, False)
+        routeFoldFun (kps, rt, vs, False) RestUnbound =
+            (kps, rt, vs, True)
+        routeFoldFun (kps, rt, vs, True) _ =
+            (kps, rt, vs, True)
+        toBS = BC8.pack . T.unpack
+
+
+(#>=) :: forall m a. MonadWriter (Trie (RouteLeaf a)) m
+      => Route -> m (Resource a) -> m ()
+k #>= mv = mv >>= (k #>)
+
 -- | Represents a fully-specified set of routes that map paths (represented as 'Route's) to 'Resource's. 'RoutingSpec's are declared with do-notation, to wit:
 --
 -- @
@@ -76,40 +139,66 @@ star = Route [RestUnbound]
 --      "anything" '</>' star                  #> wildcardResource
 -- @
 --
-newtype RoutingSpec m a = RoutingSpec { getRouter :: Writer [(Route, Resource m)] a }
-    deriving (Functor, Applicative, Monad, MonadWriter [(Route, Resource m)])
+newtype RoutingSpec m a = RoutingSpec { getRouter :: Writer (Trie (RouteLeaf m)) a }
+    deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadWriter (Trie (RouteLeaf m))
+             )
 
 type MatchedRoute a = (a, (HashMap Text Text, [Text]))
 
-route :: [(Route, a)]
-      -> [Text]
-      -> Maybe (MatchedRoute a)
-route routes pInfo = foldr' (matchRoute pInfo) Nothing routes
 
-matchRoute :: [Text]
-           -> (Route, a)
-           -> Maybe (MatchedRoute a)
-           -> Maybe (MatchedRoute a)
-matchRoute paths (rSpec, resource) previousMatch =
-    case matchesRoute paths rSpec of
-      Nothing -> previousMatch
-      Just m  -> Just (resource, m)
+route :: forall a.Trie (RouteLeaf a)
+      -> BC8.ByteString
+      -> Maybe (Resource a, (HashMap Text Text, [Text]))
+route routes pInfo = let matchRes = Trie.match routes pInfo
+                     in matchRoute' routes matchRes mempty Nothing
 
-matchesRoute :: [Text] -> Route -> Maybe (HashMap Text Text, [Text])
-matchesRoute paths spec = matchesRoute' paths (getRoute spec) (mempty, mempty) False where
-    -- recursion is over, and we never bailed out to return false, so we match
-    matchesRoute' []        []              acc     _   = Just acc
-    -- there is an extra part of the path left, and we don't have more matching
-    matchesRoute' (_ph:_ptl) []             _       _   = Nothing
-    -- we match whatever is left, so it doesn't matter what's left in the path
-    matchesRoute' r        (RestUnbound:_) (h, d)  _   = Just (h, d ++ r)
-    -- we match a specific string, and it matches this part of the path,
-    -- so recur
-    matchesRoute' (ph:ptl)  (Bound sh:stt)  (h, dispatch) True
-        | ph == sh
-                                                    = matchesRoute' ptl stt (h, dispatch ++ [ph]) True
-    matchesRoute' (ph:ptl)  (Bound sh:stt)  (h, dispatch) False
-        | ph == sh
-                                                    = matchesRoute' ptl stt (h, dispatch) False
-    matchesRoute' (ph:ptl)  (Var t:stt)     acc   _ = matchesRoute' ptl stt (insert t ph (fst acc), snd acc) True
-    matchesRoute' _         _               _acc  _ = Nothing
+
+matchRoute' :: Trie (RouteLeaf a)
+            -> Maybe (B.ByteString, RouteLeaf a, B.ByteString)
+            -> [Text]
+            -> Maybe B.ByteString
+            -> Maybe (Resource a, (HashMap Text Text, [Text]))
+matchRoute' _routes Nothing _ps _dsp =
+    -- Nothing even partially matched the route
+    Nothing
+matchRoute' routes (Just (matched, RouteMatchOrVar r vars, "")) ps dsp =
+    -- The matched key is also a prefix of other routes, but the
+    -- entire path matched so handle like a RouteMatch.
+    matchRoute' routes (Just (matched, RouteMatchOrVar r vars, "")) ps dsp
+matchRoute' _routes (Just (matched, RouteMatch r vars, "")) ps dsp =
+    -- The entire path matched so return the resource, params, and
+    -- dispatch path
+    Just (r, (fromList $ zip vars ps, dispatchList dsp matched))
+    where
+        dispatchList (Just d) m = toTextList $ B.concat [d, m]
+        dispatchList Nothing _ = mempty
+        toTextList bs = (T.pack . BC8.unpack) <$> BC8.split '/' bs
+matchRoute' _routes (Just (_matched, RouteMatch _r _vars, _)) _ps _dsp =
+    -- Part of the request path matched, but the trie value at the
+    -- matched prefix is not an RVar or RouteMatchOrVar so there is no
+    -- match.
+    Nothing
+matchRoute' routes (Just (matched, RouteMatchOrVar _r _vars, rest)) ps dsp =
+    -- Part of the request path matched and the trie value at the
+    -- matched prefix is a RouteMatchOrVar so handle it the same as if
+    -- the value were RVar.
+    matchRoute' routes (Just (matched, RVar, rest)) ps dsp
+matchRoute' routes (Just (matched, RVar, rest)) ps dsp =
+    -- Part of the request path matched and the trie value at the
+    -- matched prefix is a RVar so calculate the key for the next part
+    -- of the route and continue attempting to match.
+    let nextKey = B.concat [ hash $ B.concat [matched, "var"]
+                            , BC8.dropWhile (/='/') $ BC8.dropWhile (=='/') rest
+                            ]
+        updDsp = if isNothing dsp then Just mempty
+                 else dsp
+        paramVal = T.pack . BC8.unpack . BC8.takeWhile (/='/')
+                   $ BC8.dropWhile (=='/') rest
+        matchRes = Trie.match routes nextKey
+    in matchRoute' routes matchRes (paramVal:ps) updDsp
+matchRoute' _routes (Just (_matched, Wildcard r, rest)) _ps _dsp =
+    -- Encountered a wildcard (star) value in the trie so it's a match
+    Just (r, (mempty, (T.pack . BC8.unpack) <$> [BC8.dropWhile (=='/') rest]))

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -15,7 +15,7 @@ import           Airship.Types
 
 import           Data.ByteString    (ByteString)
 #if __GLASGOW_HASKELL__ < 710
-import           Data.Monoid        (Monoid, mappend, mempty)
+import           Data.Monoid        (mappend, mempty)
 #endif
 import           Data.Text          (Text)
 import           Data.Time.Clock    (UTCTime)
@@ -152,8 +152,3 @@ defaultResource = Resource { allowMissingPost          = return False
                            , validContentHeaders       = return True
                            , errorResponses            = mempty
                            }
-
-
-instance Monad m => Monoid (Resource m) where
-    mempty       = defaultResource
-    mappend x _  = x

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -15,7 +15,7 @@ import           Airship.Types
 
 import           Data.ByteString    (ByteString)
 #if __GLASGOW_HASKELL__ < 710
-import           Data.Monoid        (mempty)
+import           Data.Monoid        (Monoid, mappend, mempty)
 #endif
 import           Data.Text          (Text)
 import           Data.Time.Clock    (UTCTime)
@@ -116,6 +116,7 @@ data Resource m =
              , errorResponses            :: ErrorResponses m
              }
 
+
 -- | A helper function that terminates execution with @500 Internal Server Error@.
 serverError :: Monad m => Webmachine m a
 serverError = finishWith (Response status500 [] Empty)
@@ -151,3 +152,8 @@ defaultResource = Resource { allowMissingPost          = return False
                            , validContentHeaders       = return True
                            , errorResponses            = mempty
                            }
+
+
+instance Monad m => Monoid (Resource m) where
+    mempty       = defaultResource
+    mappend x _  = x

--- a/src/Airship/Route.hs
+++ b/src/Airship/Route.hs
@@ -1,12 +1,13 @@
 module Airship.Route
     ( Route
     , RoutingSpec
+    , RouteLeaf
     , root
     , var
     , star
     , (</>)
     , (#>)
+    , (#>=)
     ) where
 
-import           Airship.Types
 import           Airship.Internal.Route

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -36,7 +36,6 @@ module Airship.Types
     , putResponseBS
     , halt
     , finishWith
-    , (#>)
     ) where
 
 import           Airship.RST
@@ -55,7 +54,6 @@ import           Control.Monad.Morph
 import           Control.Monad.Reader.Class          (MonadReader, ask)
 import           Control.Monad.State.Class
 import           Control.Monad.Trans.Control         (MonadBaseControl (..))
-import           Control.Monad.Writer.Class          (MonadWriter, tell)
 import           Data.ByteString.Char8               hiding (reverse)
 import           Data.HashMap.Strict                 (HashMap)
 import           Data.Map.Strict                     (Map)
@@ -205,28 +203,6 @@ finishWith = Webmachine . failure
 -- | Adds the provided ByteString to the Airship-Trace header.
 addTrace :: Monad m => ByteString -> Webmachine m ()
 addTrace t = modify'' (\s -> s { decisionTrace = t : decisionTrace s })
-
--- | The @#>@ operator provides syntactic sugar for the construction of association lists.
--- For example, the following assoc list:
---
--- @
---     [("run", "jewels"), ("blue", "suede"), ("zion", "wolf")]
--- @
---
--- can be represented as such:
---
--- @
---     execWriter $ do
---       "run" #> "jewels"
---       "blue" #> "suede"
---       "zion" #> "wolf"
--- @
---
--- It used in 'RoutingSpec' declarations to indicate that a particular 'Route' maps
--- to a given 'Resource', but can be used in many other places where association lists
--- are expected, such as 'contentTypesProvided'.
-(#>) :: MonadWriter [(k, v)] m => k -> v -> m ()
-k #> v = tell [(k, v)]
 
 both :: Either a a -> a
 both = either id id


### PR DESCRIPTION
Update the routing to use a trie as the underlying data structure rather
than the lists. The goal of these changes are to improve both the space
efficiency of the routing information and the efficiency when performing
lookups to match the resource for a route.

I have created a criterion benchmark suite that I used to test the 
performance of these changes and it can be found [here](https://github.com/kellymclaughlin/airship-route-benchmark). The results I have gotten so far indicate this
change will have a nice benefit to routing performance, but I would welcome 
anyone to run some tests as well to verify my conclusion. Here are some links to the 
results I obtained:

* Results with current `master`: https://dl.dropboxusercontent.com/u/14268813/airship-route-bench-old.html
* Results using this branch: https://dl.dropboxusercontent.com/u/14268813/airship-route-bench-new.html

I have used this branch to run the integration tests of some of our internal 
Airship projects to verify the functionality of the changes and so far I have 
found it to work as expected and be fully compatible with existing Airship 
apps, but would certainly be happy for others to try as well.