### PR TITLE
Provide information on the route that is being evaluated for a given request

### DIFF
--- a/airship.cabal
+++ b/airship.cabal
@@ -3,7 +3,7 @@ synopsis:               A Webmachine-inspired HTTP library
 description:            A Webmachine-inspired HTTP library
 homepage:               https://github.com/helium/airship/
 Bug-reports:            https://github.com/helium/airship/issues
-version:                0.7.0
+version:                0.8.0
 license:                MIT
 license-file:           LICENSE
 author:                 Reid Draper and Patrick Thomson

--- a/src/Airship/Helpers.hs
+++ b/src/Airship/Helpers.hs
@@ -5,6 +5,7 @@ module Airship.Helpers
     , redirectPermanently
     , resourceToWai
     , resourceToWaiT
+    , resourceToWaiT'
     , appendRequestPath
     , lookupParam
     , lookupParam'

--- a/src/Airship/Internal/Date.hs
+++ b/src/Airship/Internal/Date.hs
@@ -15,7 +15,6 @@ module Airship.Internal.Date
 import           Control.Applicative         ((<$>))
 #endif
 
-import           Data.ByteString.Char8       (ByteString, pack)
 import           Data.ByteString.Char8       ()
 import           Data.ByteString.Internal
 import           Data.Time.Calendar          (fromGregorian, toGregorian)
@@ -25,14 +24,6 @@ import           Data.Word
 import           Foreign.ForeignPtr
 import           Foreign.Ptr
 import           Foreign.Storable
-
-#if MIN_VERSION_time(1,5,0)
-import           Data.Time.Format            (defaultTimeLocale, formatTime)
-#else
--- get defaultTimeLocale from old-locale
-import           Data.Time.Format            (formatTime)
-import           System.Locale               (defaultTimeLocale)
-#endif
 
 import qualified Network.HTTP.Date           as HD
 

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -121,6 +121,10 @@ resourceToWaiT cfg run routes errors req respond =
 -- | Like 'resourceToWaiT', but expects the 'RoutingSpec' to have been
 -- evaluated with 'runRouter'. This is more efficient than 'resourceToWaiT', as
 -- the routes will not be evaluated on every request.
+-- 
+-- Given @routes :: RoutingSpec IO ()@, 'resourceToWaiT'' can be invoked like so:
+--
+-- > resourceToWaiT' cfg (const id) (runRouter routes) errors
 resourceToWaiT' :: Monad m
                => AirshipConfig
                -> (AirshipRequest -> m Wai.Response -> IO Wai.Response)

--- a/src/Airship/Internal/Helpers.hs
+++ b/src/Airship/Internal/Helpers.hs
@@ -30,6 +30,7 @@ import           Data.Foldable             (forM_)
 import qualified Data.HashMap.Strict       as HM
 import qualified Data.Map.Strict           as M
 import           Data.Text                 (Text)
+import           Data.Text.Encoding        (decodeUtf8)
 import           Data.Time                 (getCurrentTime)
 import           Lens.Micro                ((^.))
 import           Network.HTTP.Media
@@ -121,7 +122,7 @@ resourceToWaiT cfg run routes errors req respond = do
     let (er, (reqParams, dispatched), routePath', r) =
          case route routeMapping pInfo of
              Nothing ->
-                 (errors, (mempty, []), "", return $ Response HTTP.status404 [(HTTP.hContentType, "text/plain")] Empty)
+                 (errors, (mempty, []), decodeUtf8 pInfo, return $ Response HTTP.status404 [(HTTP.hContentType, "text/plain")] Empty)
              Just (RoutedResource rPath resource, pm) ->
                  (M.union (errorResponses resource) errors, pm, routeText rPath, flow resource)
         airshipReq = AirshipRequest req routePath'

--- a/src/Airship/Internal/Route.hs
+++ b/src/Airship/Internal/Route.hs
@@ -10,6 +10,7 @@ module Airship.Internal.Route
     , Route
     , RouteLeaf
     , RoutedResource(..)
+    , Trie
     , root
     , var
     , star
@@ -81,6 +82,8 @@ data RouteLeaf m = RouteMatch (RoutedResource m) [Text]
                  | Wildcard (RoutedResource m)
 
 
+-- | Turns the list of routes in a 'RoutingSpec' into a 'Trie' for efficient
+-- routing
 runRouter :: RoutingSpec m a -> Trie (RouteLeaf m)
 runRouter routes = toTrie $ execWriter (getRouter routes)
     where

--- a/src/Airship/Route.hs
+++ b/src/Airship/Route.hs
@@ -2,12 +2,14 @@ module Airship.Route
     ( Route
     , RoutingSpec
     , RouteLeaf
+    , Trie
     , root
     , var
     , star
     , (</>)
     , (#>)
     , (#>=)
+    , runRouter
     ) where
 
 import           Airship.Internal.Route


### PR DESCRIPTION
For the requested URL, it is useful to get the route (that is, what was specified in `RoutingSpec` without path parameters) that was evaluated for logging, debugging, and other uses.

This work makes the following changes:

* Adds a `routePath` function in the `Webmachine` context to access the evaluated route as `Text`.
* Adds a new type, `AirshipRequest`. This type gives us ability to add more information than is provided in the WAI `Request` type. Currently, the constructor contains both the WAI `Request` and the evaluted route as `Text`.
* Changed the type signature of `resourceToWaiT` to use `AirshipRequest` rather than `Request` in the "middleware" function.
* A new `resourceToWaiT'` function, which takes a `Trie` of routes, rather than a `RoutingSpec`. This is more efficient than `resourceToWaiT`, which evaluates the `RoutingSpec` on every request (which may be something that is desired with more complicated routing scheme
s). 
* Minor code and documentation cleanup

The version has been updated to 0.8.0, as this changes externally-facing type signatures.